### PR TITLE
Change ordering for orderByRaw example

### DIFF
--- a/sections/builder.js
+++ b/sections/builder.js
@@ -944,14 +944,15 @@ export default [
   },
   {
     type: "method",
-    method: "orderByRaw",
+    method: "
+    ",
     example: ".orderByRaw(sql)",
     description: "Adds an order by raw clause to the query.",
     children: [
       {
         type: "runnable",
         content: `
-          knex.select('*').from('table').orderByRaw('col NULLS LAST DESC')
+          knex.select('*').from('table').orderByRaw('col DESC NULLS LAST')
         `
       }
     ]


### PR DESCRIPTION
According to the [Postgres Sorting Docs](https://www.postgresql.org/docs/current/static/queries-order.html) the order should be swapped.