### PR TITLE
Add custom migration stub documentation

### DIFF
--- a/sections/migrations.js
+++ b/sections/migrations.js
@@ -187,6 +187,28 @@ export default [
   },
   {
     type: "heading",
+    size: "sm",
+    content: "Custom migration:"
+  },
+  {
+    type: "text",
+    size: "sm",
+    content: "You may provide a custom migration stub to be used in place of the default option."
+  },
+  {
+    type: "code",
+    language: "js",
+    content: `
+      module.exports = {
+        client: 'pg',
+        migration: {
+          stub: 'migration.stub'
+        }
+      };
+    `
+  },
+  {
+    type: "heading",
     size: "md",
     content: "Migration API",
     href: "Migrations-API"


### PR DESCRIPTION
Adding documentation on how to include a custom stub for migrations.

Here's how it looks:
 
<img width="613" alt="screen shot 2016-12-09 at 4 04 22 pm" src="https://cloud.githubusercontent.com/assets/3803621/21069060/324df784-be2b-11e6-80b5-4112ba59c40f.png">

Closes tgriesser/knex#1319