### PR TITLE
Amend search query

### DIFF
--- a/sections/builder.js
+++ b/sections/builder.js
@@ -212,7 +212,7 @@ export default [
   {
     type: "runnable",
     content: `
-      knex('users').where('columnName', 'like', \`%\${searchTerm}%\`)
+      knex('users').where('columnName', 'like', %'red'%)
     `
   },
   {


### PR DESCRIPTION
Some time ago I added an example query using `like`. This was just merged in, but I used the variable `searchTerm` wrapped in a template literal, leading to this error showing up on the live version of the site:  
![error](https://cloud.githubusercontent.com/assets/16832997/23049937/2c31a64a-f524-11e6-8525-0416d27b3beb.PNG)
This PR changes it to a string.
