### PR TITLE
Add clearer params for table.specificType()

### DIFF
--- a/sections/schema.js
+++ b/sections/schema.js
@@ -390,7 +390,7 @@ export default [
   {
     type: "method",
     method: "specificType",
-    example: "table.specificType(column, value)",
+    example: "table.specificType(name, type)",
     description: "Sets a specific type for the column creation, if you'd like to add a column type that isn't supported here.",
     children: [    ]
   },


### PR DESCRIPTION
When I read this in the docs, I was confused by `(column, value)` -- which one was the field name, which was the field type? Proposing renaming these in the docs. [Verification of functionality](https://github.com/tgriesser/knex/blob/e63fe2255534869849bf460b5e4aec5fce253ef8/test/unit/schema/postgres.js#L623).