### PR TITLE
Change documentation for cross-join

### DIFF
--- a/sections/builder.js
+++ b/sections/builder.js
@@ -715,8 +715,14 @@ export default [
     type: "method",
     method: "crossJoin",
     example: ".crossJoin(column, ~mixed~)",
-    description: "",
+    description: "Cross join conditions are only supported in MySQL and SQLite3. For join conditions rather use innerJoin.",
     children: [
+      {
+        type: "runnable",
+        content: `
+          knex.select('*').from('users').crossJoin('accounts')
+        `
+      },
       {
         type: "runnable",
         content: `


### PR DESCRIPTION
* When cross-join is used it is common
  to use it without any join condition

* I simplified first example to use no
  condition and retained the second one
  with condition

* However using cross join with ON condition
  is not good idea and not good example. It
  works only in MySQL and sqlite3, other DB
  systems will throw and error and also
  for that purpose it is better to use innerJoin, so
  I also added comment that explains that