### PR TITLE
(fix): builder options example

### DIFF
--- a/sections/builder.js
+++ b/sections/builder.js
@@ -1676,7 +1676,7 @@ export default [
             })
             .select(['a1.email', 'a2.email'])
             .where(knex.raw('a1.id = 1'))
-            .option({ nestTables: true, rowMode: 'array' })
+            .options({ nestTables: true, rowMode: 'array' })
             .limit(2)
             .then(...
         `


### PR DESCRIPTION
The example was incorrect using `option` instead of `options`.