### PR TITLE
Added new alias syntax select({alias: 'column'})

### DIFF
--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -43,6 +43,7 @@ export default class Sidebar extends Component {
           Query Builder
         </a>
         <ul className="toc_section">
+          <li>– <a href="#Builder-identifier-syntax"><b>Identifier Syntax</b></a></li>
           <li>– <a href="#Builder-knex"><b>constructor</b></a></li>
           <li>– <a href="#Builder-timeout">timeout</a></li>
           <li>– <a href="#Builder-select">select</a></li>

--- a/sections/builder.js
+++ b/sections/builder.js
@@ -10,6 +10,33 @@ export default [
     content: "The heart of the library, the knex query builder is the interface used for building and executing standard SQL queries, such as `select`, `insert`, `update`, `delete`."
   },
   {
+    type: "heading",
+    size: "md",
+    content: "Identifier Syntax",
+    href: "Builder-identifier-syntax"
+  },
+  {
+    type: "text",
+    content: [
+      "In many places in APIs identifiers like table name or column name can be passed to methods.",
+      "Most commonly one needs just plain `tableName.columnName`, `tableName` or `columnName`, but in many cases one also needs to pass an alias how that identifier is referred later on in the query.",
+      "There are two ways to declare an alias for identifier. One can directly give `as aliasName` prefix for the identifier or oen can pass an object `{ aliasName: 'identifierName' }`.",
+      "If in the object has multiple aliases `{ alias1: 'identifier1', alias2: 'identifier2' }`, then all the aliased identifiers are expanded to comma separated list.",
+      "NOTE: identifier syntax has no place for selecting schema, so if you are doing `schemaName.tableName`, query might be rendered wrong. Use `.withSchema('schemaName')` instead."
+    ]
+  },
+  {
+    type: "runnable",
+    content: `
+      knex({ a: 'table', b: 'table' })
+        .select({
+          aTitle: 'a.title',
+          bTitle: 'b.title'
+        })
+        .whereRaw('?? = ??', ['a.column_1', 'b.column_2'])
+    `
+  },
+  {
     type: "method",
     method: "knex",
     example: "knex(tableName, options={only: boolean}) / knex.[methodName]",

--- a/sections/builder.js
+++ b/sections/builder.js
@@ -76,7 +76,7 @@ export default [
     type: "method",
     method: "column",
     example: ".column(columns)",
-    description: "Specifically set the columns to be selected on a select query, taking an array or a list of of column names.",
+    description: "Specifically set the columns to be selected on a select query, taking an array, an object or a list of column names. Passing an object will automatically alias the columns with the given keys.",
     children: [
       {
         type: "runnable",
@@ -88,6 +88,12 @@ export default [
         type: "runnable",
         content: `
           knex.column(['title', 'author', 'year']).select().from('books')
+        `
+      },
+      {
+        type: "runnable",
+        content: `
+          knex.column('title', {by: 'author'}, 'year').select().from('books')
         `
       }
     ]


### PR DESCRIPTION
Here is the documentation for the new alias syntax (https://github.com/tgriesser/knex/pull/2227)