### PR TITLE
Fix typo in migrations.js

### DIFF
--- a/sections/migrations.js
+++ b/sections/migrations.js
@@ -201,7 +201,7 @@ export default [
     content: `
       module.exports = {
         client: 'pg',
-        migration: {
+        migrations: {
           stub: 'migration.stub'
         }
       };


### PR DESCRIPTION
The correct key is `migrations`. Setting your config to `migration` doesn't do anything.