### PR TITLE
Fix anchors for duplicate / invalid ids

### DIFF
--- a/components/Method.jsx
+++ b/components/Method.jsx
@@ -11,13 +11,14 @@ export default class Method extends Component {
     example: PropTypes.string,
     children: PropTypes.array,
     description: PropTypes.string,
-    method: PropTypes.string.isRequired
+    method: PropTypes.string.isRequired,
+    id: PropTypes.string
   };
 
   render() {
     const {
       context: {section},
-      props: {method, example, children, description}
+      props: {method, example, children, description, id}
     } = this
 
     let methodContent = []
@@ -33,7 +34,7 @@ export default class Method extends Component {
     }
 
     return (
-      <div id={`${section}-${method}`}>
+      <div id={id ? id : `${section}-${method}`}>
         <b>{method}</b>
         {example && ` — `}
         {example && <code>{example}</code>}

--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -205,8 +205,8 @@ export default class Sidebar extends Component {
           <li>– <a href="#Schema-nullable">nullable</a></li>
           <li>– <a href="#Schema-first">first</a></li>
           <li>– <a href="#Schema-after">after</a></li>
-          <li>– <a href="#Schema-comment">comment</a></li>
-          <li>– <a href="#Schema-collate">collate</a></li>
+          <li>– <a href="#Column-comment">comment</a></li>
+          <li>– <a href="#Column-collate">collate</a></li>
         </ul>
 
         <a className="toc_title" href="#Raw">

--- a/sections/schema.js
+++ b/sections/schema.js
@@ -330,6 +330,7 @@ export default [
   },
   {
     type: "method",
+    id: "Schema-enum",
     method: "enum / enu",
     example: "table.enu(col, values)",
     description: "Adds a enum column, (aliased to enu, as enum is a reserved word in JavaScript). Note that the second argument is an array of values. Example:",
@@ -614,6 +615,7 @@ export default [
     method: "comment",
     example: "column.comment(value)",
     description: "Sets the comment for a column.",
+    id: "Column-comment",
     children: [    ]
   },
   {
@@ -630,6 +632,7 @@ export default [
     method: "collate",
     example: "column.collate(collation)",
     description: "Sets the collation for a column (only works in MySQL). Here is a list of all available collations: https://dev.mysql.com/doc/refman/5.5/en/charset-charsets.html",
+    id: "Column-collate",
     children: [    ]
   },
   {


### PR DESCRIPTION
Currently, you can't navigate to the Chainable -> Comment, Chainable -> Collate and Schema -> Enum entries, because the referenced ids are invalid (Schema-enum / enu) oder duplicate (Schema-comment and Schema-collate). I fixed this by adding the ability to manually override the generated id with valid / unique ids.