### PR TITLE
Transaction: add notes about trx.rollback()

### DIFF
--- a/sections/transactions.js
+++ b/sections/transactions.js
@@ -99,6 +99,7 @@ export default [
     content: [
       "Throwing an error directly from the transaction handler function automatically rolls back the transaction, same as returning a rejected promise.",
       "Notice that if a promise is not returned within the handler, it is up to you to ensure `trx.commit`, or `trx.rollback` are called, otherwise the transaction connection will hang.",
+      "Calling `trx.rollback` will return a rejected Promise. If you don't pass any argument to `trx.rollback`, a generic `Error` object will be created and passed in to ensure the Promise always rejects with something.",
       "Note that Amazon Redshift does not support savepoints in transactions.",
     ]
   }


### PR DESCRIPTION
While working on defining an accurate Flow type for `trx.rollback()`, I encountered some difficulties asserting whether one must pass an `Error` object to `trx.callback()`. The whole discussion/investigation can be found there: https://github.com/flowtype/flow-typed/pull/1947.

Please let me know if the assertion made in this pull request is wrong.