### PR TITLE
Remove seed notice to delete records

### DIFF
--- a/sections/migrations.js
+++ b/sections/migrations.js
@@ -140,7 +140,7 @@ export default [
   },
   {
     type: "text",
-    content: "Seed files are executed in alphabetical order. Unlike migrations, _every_ seed file will be executed when you run the command. You should design your seed files to reset tables as needed before inserting data."
+    content: "Seed files are executed in alphabetical order. Unlike migrations, _every_ seed file will be executed when you run the command."
   },
   {
     type: "heading",


### PR DESCRIPTION
What was the reasoning behind this suggestion/advice?

I find this suggestion quite dangerous as seed files can and will be run on production to seed the initial required records. For instance, creating an "admin user" so you can login on your newly deployed application... 

I received a PR today on our project deleting all user records because "knex suggested it" and I wanted to bring this to your attention. If a "table reset" is required, engineers know what to do, suggesting it as the default can mislead less experienced engineers.