### PR TITLE
Add missing queryContext to sidebar with Method component fragment link bug fix

### DIFF
--- a/components/Method.jsx
+++ b/components/Method.jsx
@@ -12,13 +12,13 @@ export default class Method extends Component {
     children: PropTypes.array,
     description: PropTypes.string,
     method: PropTypes.string.isRequired,
-    id: PropTypes.string
+    href: PropTypes.string
   };
 
   render() {
     const {
       context: {section},
-      props: {method, example, children, description, id}
+      props: {method, example, children, description, href}
     } = this
 
     let methodContent = []
@@ -34,7 +34,7 @@ export default class Method extends Component {
     }
 
     return (
-      <div id={id ? id : `${section}-${method}`}>
+      <div id={href ? href : `${section}-${method}`}>
         <b>{method}</b>
         {example && ` — `}
         {example && <code>{example}</code>}

--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -156,6 +156,7 @@ export default class Sidebar extends Component {
           <li>– <a href="#Schema-dropTableIfExists">dropTableIfExists</a></li>
           <li>– <a href="#Schema-table">table</a></li>
           <li>– <a href="#Schema-raw">raw</a></li>
+          <li>– <a href="#Schema-queryContext">queryContext</a></li>
           <li><b><a href="#Schema-Building">Schema Building:</a></b></li>
           <li>– <a href="#Schema-dropColumn">dropColumn</a></li>
           <li>– <a href="#Schema-dropColumns">dropColumns</a></li>
@@ -192,6 +193,7 @@ export default class Sidebar extends Component {
           <li>– <a href="#Schema-dropForeign">dropForeign</a></li>
           <li>– <a href="#Schema-dropUnique">dropUnique</a></li>
           <li>– <a href="#Schema-dropPrimary">dropPrimary</a></li>
+          <li>– <a href="#Schema-table-queryContext">queryContext</a></li>
           <li><a href="#Chainable"><b>Chainable:</b></a></li>
           <li>– <a href="#Schema-alter">alter</a></li>
           <li>– <a href="#Schema-index">index</a></li>

--- a/sections/schema.js
+++ b/sections/schema.js
@@ -368,7 +368,7 @@ export default [
   },
   {
     type: "method",
-    id: "Schema-enum",
+    href: "Schema-enum",
     method: "enum / enu",
     example: "table.enu(col, values, [options])",
     description: "Adds a enum column, (aliased to enu, as enum is a reserved word in JavaScript). Implemented as unchecked varchar(255) on Amazon Redshift. Note that the second argument is an array of values. Example:",
@@ -727,7 +727,7 @@ export default [
     method: "comment",
     example: "column.comment(value)",
     description: "Sets the comment for a column.",
-    id: "Column-comment",
+    href: "Column-comment",
     children: [    ]
   },
   {
@@ -744,7 +744,7 @@ export default [
     method: "collate",
     example: "column.collate(collation)",
     description: "Sets the collation for a column (only works in MySQL). Here is a list of all available collations: https://dev.mysql.com/doc/refman/5.5/en/charset-charsets.html",
-    id: "Column-collate",
+    href: "Column-collate",
     children: [    ]
   },
   {


### PR DESCRIPTION
First thing I found was that recent sidebar update only added queryContext for QueryBuilder, but queryContext also appears in SchemaBuilder section twice. Thus, I added those two missing queryContext sidebar entries.

However, shortly I noticed that sidebar link does not work for `queryContext — table.queryContext(context)` entry. It was because Heading react component uses `href` prop as dom element id while Method react component use `id` prop as dom element id.

Those two different prop names with same role might cause misusing `href` as prop name, even in Method component. We can see this occured at schema.js:544:
```javascript
 {
    type: "method",
    method: "queryContext",
    example: "table.queryContext(context)",
    href: "Schema-table-queryContext", // <== HERE! fragment link does not work for this
    description: [
      "Allows configuring a context to be passed to the [wrapIdentifier](#Installation-wrap-identifier) hook for formatting table builder identifiers.",
      "The context can be any kind of value and will be passed to `wrapIdentifier` without modification."
    ].join(" "),
    ...
```
Consequently, I changed Method component's `id` prop to `href`, because `href` is more frequently used in codes.