### PR TITLE
Document Knex pull request #2961

### DIFF
--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -118,6 +118,8 @@ export default class Sidebar extends Component {
           <li>– <a href="#Builder-transacting">transacting</a></li>
           <li>&nbsp;&nbsp;– <a href="#Builder-forUpdate">forUpdate</a></li>
           <li>&nbsp;&nbsp;– <a href="#Builder-forShare">forShare</a></li>
+          <li>– <a href="#Builder-skipLocked">skipLocked</a></li>
+          <li>– <a href="#Builder-noWait">noWait</a></li>
           <li>– <a href="#Builder-count">count</a></li>
           <li>– <a href="#Builder-min">min</a></li>
           <li>– <a href="#Builder-max">max</a></li>

--- a/sections/builder.js
+++ b/sections/builder.js
@@ -1565,7 +1565,7 @@ export default [
     type: "method",
     method: "skipLocked",
     example: ".skipLocked()",
-    description: "PostgreSQL only. This method can be used after a lock mode has been specified with either forUpdate or forShare, and will cause the query to skip any locked rows, returning an empty set if none are available.",
+    description: "MySQL 8.0+ and PostgreSQL 9.5+ only. This method can be used after a lock mode has been specified with either forUpdate or forShare, and will cause the query to skip any locked rows, returning an empty set if none are available.",
     children: [
       {
         type: "runnable",
@@ -1582,7 +1582,7 @@ export default [
     type: "method",
     method: "noWait",
     example: ".noWait()",
-    description: "PostgreSQL only. This method can be used after a lock mode has been specified with either forUpdate or forShare, and will cause the query to fail immediately if any selected rows are currently locked.",
+    description: "MySQL 8.0+ and PostgreSQL 9.5+ only. This method can be used after a lock mode has been specified with either forUpdate or forShare, and will cause the query to fail immediately if any selected rows are currently locked.",
     children: [
       {
         type: "runnable",

--- a/sections/builder.js
+++ b/sections/builder.js
@@ -1563,6 +1563,40 @@ export default [
   },
   {
     type: "method",
+    method: "skipLocked",
+    example: ".skipLocked()",
+    description: "PostgreSQL only. This method can be used after a lock mode has been specified with either forUpdate or forShare, and will cause the query to skip any locked rows, returning an empty set if none are available.",
+    children: [
+      {
+        type: "runnable",
+        content: `
+          knex('tableName')
+            .select('*')
+            .forUpdate()
+            .skipLocked()
+        `
+      }
+    ]
+  },
+  {
+    type: "method",
+    method: "noWait",
+    example: ".noWait()",
+    description: "PostgreSQL only. This method can be used after a lock mode has been specified with either forUpdate or forShare, and will cause the query to fail immediately if any selected rows are currently locked.",
+    children: [
+      {
+        type: "runnable",
+        content: `
+          knex('tableName')
+            .select('*')
+            .forUpdate()
+            .noWait()
+        `
+      }
+    ]
+  },
+  {
+    type: "method",
     method: "count",
     example: ".count(column|columns|raw)",
     description: "Performs a count on the specified column or array of columns (note that some drivers do not support multiple columns). Also accepts raw expressions. Note that in Postgres, count returns a bigint type which will be a String and not a Number (more info).",


### PR DESCRIPTION
Documentation draft for https://github.com/tgriesser/knex/pull/2961

This is partially untested, as I can't make it build with my branch of knex from GitHub without Babel going into an error loop, and the upstream version can't compile the new queries. So, I don't know what happens to the query preview when you switch it to an unsupported database.