### PR TITLE
Fix npm run dev

### DIFF
--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -66,7 +66,7 @@ portfinder.getPorts(2, {}, (portFinderErr, [docsPort, webpackPort]) => {
 
   runCmd('webpack-dev-server', `node_modules/.bin/nodemon --watch webpack --watch scripts/webpack.config.js --exec webpack-dev-server -- --config scripts/webpack.config.js --color --port ${webpackPort} --debug --hot --host ${ip.address()}`)
 
-  runCmd('docs-server', 'node_modules/.bin/nodemon -- --watch components --watch sections -e js,jsx --exec babel-node scripts/server.js', {
+  runCmd('docs-server', 'node_modules/.bin/nodemon --watch components --watch sections -e js,jsx --exec babel-node scripts/server.js', {
     env: {
       PORT: docsPort,
       WEBPACK_DEV_PORT: webpackPort,


### PR DESCRIPTION
I am unable to run `npm run dev` because nodemon forwards the arguments after `--` to `node` which doesn't recognize `--watch`. 

I am curious why this hasn't been problematic for other contributors, as this script has been untouched since last 2 yrs.