### PR TITLE
Add Missing function from sidebar

### DIFF
--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -100,6 +100,7 @@ export default class Sidebar extends Component {
           <li>&nbsp;&nbsp;– <a href="#Builder-clearSelect">clearSelect</a></li>
           <li>&nbsp;&nbsp;– <a href="#Builder-clearWhere">clearWhere</a></li>
           <li>&nbsp;&nbsp;– <a href="#Builder-clearOrder">clearOrder</a></li>
+          <li>&nbsp;&nbsp;– <a href="#Builder-clearHaving">clearHaving</a></li>
           <li>&nbsp;&nbsp;– <a href="#Builder-clearCounters">clearCounters</a></li>
 
           <li>– <a href="#Builder-distinct">distinct</a></li>


### PR DESCRIPTION
This PR just adds the `clearHaving` function to the sidebar. I had missed adding it here in my previous PR. (#190)