### PR TITLE
Improve dev workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/build/* binary
+index.html binary

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,4 @@
+{
+    "ignoreRoot": [".git"],
+    "restartable": false
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "babel-preset-es2015-loose": "^7.0.0",
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-1": "^6.13.0",
-    "child-process-promise": "^2.0.3",
     "colors": "^1.1.2",
     "css-loader": "^2.0.1",
     "dedent": "^0.7.0",
@@ -47,7 +46,8 @@
     "webpack": "^4.27.1",
     "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.1.14",
-    "yargs": "^4.8.1"
+    "yargs": "^4.8.1",
+    "execa": "^1.0.0"
   },
   "author": {
     "name": "Tim Griesser",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,68 +1,21 @@
 /* eslint no-console: 0 */
 import 'colors'
-import { exec } from 'child-process-promise'
-
-const SIGINT = 'SIGINT'
-let processMap = {}
-
-function output(prefix, message) {
-  let formattedMessage = message.toString().trim().split('\n')
-    .reduce((acc, line) => `${acc}${ acc !== '' ? '\n' : '' }${prefix} ${line}`, '')
-
-  console.log(formattedMessage)
-}
-
-function listen({stdout, stderr}, name) {
-  stdout.on('data', data => output(`[${name}] `.grey, data))
-  stderr.on('data', data => output(`[${name}] `.grey, data))
-}
-
-function shutdown() {
-  Object.values(processMap).forEach(process => process.kill(SIGINT))
-}
-
-function catchExec(name, err) {
-  if (err.killed) {
-    console.log('Shutdown: '.cyan + name.green)
-    shutdown()
-    return false
-  }
-
-  console.log(`${name} -- Failed`.red)
-  console.log(err.toString().red)
-  return true
-}
-
-function runCmd(name, cmd, options) {
-  return exec(cmd, options)
-    .progress(childProcess => {
-      listen(childProcess, name)
-      processMap[name] = childProcess
-      return
-    })
-    .then(() => console.log('Shutdown: '.cyan + name.green))
-    .catch(err => {
-      if (catchExec(name, err)) {
-        // Restart if not explicitly shutdown
-        runCmd(name, cmd, options)
-      }
-    })
-}
+import execa from 'execa'
+import {formatOutputStream} from './utils'
 
 console.log('Building docs for production'.cyan)
-
-process.on(SIGINT, shutdown)
 
 const env = {
   ...process.env,
   NODE_ENV: 'production'
 }
 
-const isWin = process.platform === "win32"
-const prefix = isWin ? 'call ' : ''
-const extension = isWin ? '.cmd' : ''
+formatOutputStream('docs-server', execa('babel-node', [
+  'scripts/server.js'
+], {env}))
 
-runCmd('docs-server', `${prefix}node_modules/.bin/babel-node${extension} scripts/server.js`, { env }).then(() => {
-  console.log('Building webpack for production'.cyan)
-  return runCmd('webpack', `${prefix}node_modules/.bin/webpack${extension} -p --config scripts/webpack.config.js`, { env })
-})
+formatOutputStream('webpack', execa('webpack', [
+  '-p',
+  '--config', 'scripts/webpack.config.js',
+  '--color'
+], {env}))

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -2,61 +2,13 @@
 
 import 'colors'
 import portfinder from 'portfinder'
-import { exec } from 'child-process-promise'
+import execa from 'execa'
 import ip from 'ip'
+import {formatOutputStream} from './utils'
 
 portfinder.basePort = 4000
 
-const SIGINT = 'SIGINT'
-let processMap = {}
-
-function output(prefix, message) {
-  let formattedMessage = message.toString().trim().split('\n')
-    .reduce((acc, line) => `${acc}${ acc !== '' ? '\n' : '' }${prefix} ${line}`, '')
-
-  console.log(formattedMessage)
-}
-
-function listen({stdout, stderr}, name) {
-  stdout.on('data', data => output(`[${name}] `.grey, data))
-  stderr.on('data', data => output(`[${name}] `.grey, data))
-}
-
-function shutdown() {
-  Object.values(processMap).forEach(process => process.kill(SIGINT))
-}
-
-function catchExec(name, err) {
-  if (err.killed) {
-    console.log('Shutdown: '.cyan + name.green)
-    shutdown()
-    return false
-  }
-
-  console.log(`${name} -- Failed`.red)
-  console.log(err.toString().red)
-  return true
-}
-
-function runCmd(name, cmd, options) {
-  exec(cmd, options)
-    .progress(childProcess => {
-      listen(childProcess, name)
-      processMap[name] = childProcess
-      return
-    })
-    .then(() => console.log('Shutdown: '.cyan + name.green))
-    .catch(err => {
-      if (catchExec(name, err)) {
-        // Restart if not explicitly shutdown
-        runCmd(name, cmd, options)
-      }
-    })
-}
-
 console.log('Starting docs in Development mode'.cyan)
-
-process.on(SIGINT, shutdown)
 
 portfinder.getPorts(2, {}, (portFinderErr, [docsPort, webpackPort]) => {
   if (portFinderErr) {
@@ -64,13 +16,30 @@ portfinder.getPorts(2, {}, (portFinderErr, [docsPort, webpackPort]) => {
     process.exit(1)
   }
 
-  runCmd('webpack-dev-server', `node_modules/.bin/nodemon --watch webpack --watch scripts/webpack.config.js --exec webpack-dev-server -- --config scripts/webpack.config.js --color --port ${webpackPort} --debug --hot --host ${ip.address()}`)
+  formatOutputStream('webpack-dev-server', execa('nodemon', [
+      '--watch', 'webpack',
+      '--watch', 'scripts/webpack.config.js',
+      '--exec', 'webpack-dev-server',
+      '--',
+      '--config', 'scripts/webpack.config.js',
+      '--color',
+      '--port', webpackPort,
+      '--debug',
+      '--hot',
+      '--host', ip.address()
+  ]))
 
-  runCmd('docs-server', 'node_modules/.bin/nodemon --watch components --watch sections -e js,jsx --exec babel-node scripts/server.js', {
-    env: {
-      PORT: docsPort,
-      WEBPACK_DEV_PORT: webpackPort,
-      ...process.env
-    }
-  })
+  formatOutputStream('docs-server', execa('nodemon', [
+      '--watch', 'components',
+      '--watch', 'sections',
+      '--watch', require.resolve('knex/CHANGELOG.md'),
+      '-e', 'js,jsx',
+      '--exec', 'babel-node scripts/server.js'
+  ], {
+      env: {
+        PORT: docsPort,
+        WEBPACK_DEV_PORT: webpackPort,
+        ...process.env
+      }
+  }))
 })

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,0 +1,11 @@
+function output(prefix, message) {
+  let formattedMessage = message.toString().trim().split('\n')
+    .reduce((acc, line) => `${acc}${ acc !== '' ? '\n' : '' }${prefix} ${line}`, '')
+
+  console.log(formattedMessage)
+}
+
+export function formatOutputStream(name, {stdout, stderr}) {
+  stdout.on('data', data => output(`[${name}] `.grey, data))
+  stderr.on('data', data => output(`[${name}] `.grey, data))
+}


### PR DESCRIPTION
Tweak build scripts to improve the dev workflow: 

1. prevent generated files from clobbering the diffs.
2. Address issues pointed out by @elhigu in https://github.com/knex/documentation/pull/196#issuecomment-496296500. 
    - Replace child-process-promise with [execa](https://github.com/sindresorhus/execa) which correctly handles SIGINT propagation & PATHEXT normalization
    - Read CHANGELOG from node_modules/knex so that it works well with npm/yarn link and nodemon can pickup changes and restart server automatically
    - Remove misleading log that rs will restart nodemon which doesn't work with spawn
