### PR TITLE
Added documentation changes for multiple seed support

### DIFF
--- a/sections/seeds.js
+++ b/sections/seeds.js
@@ -15,9 +15,10 @@ export default [
   {
     type: "list",
     content: [
-      "`directory`: a relative path to the directory containing the seed files (default `./seeds`)",
+      "`directory`: a relative path to the directory containing the seed files. Can be an array of paths (default `./seeds`)",
       "`loadExtensions`: array of file extensions which knex will treat as seeds. For example, if you have typescript transpiled into javascript in the same folder, you want to execute only javascript seeds. In this case, set `loadExtensions` to `['.js']`  (Notice the dot!)  (default `['.co', '.coffee', '.eg', '.iced', '.js', '.litcoffee', '.ls', '.ts']`)",
-      "`specific`: a specific seed file to run from the seeds directory, if its value is `undefined` it will run all the seeds (default `undefined`)"
+      "`specific`: a specific seed file to run from the seeds directory, if its value is `undefined` it will run all the seeds (default `undefined`)",
+      "`sortDirsSeparately`: if true and multiple directories are specified, all migrations from a single directory will be executed before executing migrations in the next folder (default `false`)"
     ]
   },
   {
@@ -29,9 +30,16 @@ export default [
   {
     type: "method",
     method: "make",
-    example: "knex.seed.make(name, [config])",
+    example: "knex.seed.make(name, [config], [subdirectory])",
     description: "Creates a new seed file, with the name of the seed file being added.",
     children: [    ]
+  },
+  {
+    type: "list",
+    content: [
+      "`subdirectory`: Must be specified if there are multiple seed directories.",
+      "`name`: May be prefixed with seed subdirectory instead of specifying a subdirectory through the subdirectory argument (e.g: `production/my-seed-file`)."
+    ]
   },
   {
     type: "method",


### PR DESCRIPTION
# Modifies documentation to include the new support for multiple seed directories

Here's a picture of the old documentation's "Seed API" section compared to the new one (_new on right-hand side_):

![image](https://user-images.githubusercontent.com/5856981/61314231-07989180-a7b1-11e9-9efe-0ca9c036d946.png)
