### PR TITLE
fix(syntax error): small issue with docs displaying invalid JS code.

### DIFF
--- a/sections/installation.js
+++ b/sections/installation.js
@@ -220,7 +220,7 @@ export default [
     content: `
       var knex = require('knex')({
         // Params
-      };
+      });
       
       var knexWithParams = knex.withUserParams({customUserParam: 'table1'});
       var customUserParam = knexWithParams.userParams.customUserParam;


### PR DESCRIPTION
Minor issue of a syntax error in documentation which would produce something along the lines of,

SyntaxError: Unexpected token, expected ","

Really not a big deal just thought i'd send a PR in.