### PR TITLE
Updated `.update(data, returning)` documentation

### DIFF
--- a/sections/builder.js
+++ b/sections/builder.js
@@ -1682,13 +1682,10 @@ export default [
       {
         type: "runnable",
         content: `
-          // Returns [2] in \"mysql\", \"sqlite\"; [2, 3] in \"postgresql\"
+          // Returns [ { id: 42, title: "The Hitchhiker's Guide to the Galaxy" } ]
           knex('books')
             .where({ id: 42 })
-            .update({ title: 'The Hitchhiker\'s Guide to the Galaxy' }, ['id', 'title'])
-            .then((updatedRows) => {
-              // updatedRows === [{id: 42, title: 'The Hitchhiker\'s Guide to the Galaxy'}]
-            })
+            .update({ title: "The Hitchhiker's Guide to the Galaxy" }, ['id', 'title'])
         `
       }
     ]


### PR DESCRIPTION
Not sure if I should've included the files for `npm run build` here.

The sole reason for this PR is that the update doc in question had some weird comments, and the generated example output doesn't support using `then` on it. Since all other examples had a `// Returning` above it, it seemed fitting to change this example to follow suit.