### PR TITLE
Edit table names in example to be plural

### DIFF
--- a/sections/migrations.js
+++ b/sections/migrations.js
@@ -382,12 +382,12 @@ export default [
     content: `
       exports.up = function(knex) {
         return knex.schema
-          .createTable('user', function (table) {
+          .createTable('users', function (table) {
              table.increments('id');
              table.string('first_name', 255).notNullable();
              table.string('last_name', 255).notNullable();
           })
-          .createTable('product', function (table) {
+          .createTable('products', function (table) {
              table.increments('id');
              table.decimal('price').notNullable();
              table.string('name', 1000).notNullable();
@@ -396,8 +396,8 @@ export default [
 
       exports.down = function(knex) {
         return knex.schema
-            .dropTable("product")
-            .dropTable("user");
+            .dropTable("products")
+            .dropTable("users");
       };
 
       exports.config = { transaction: false };


### PR DESCRIPTION
Change table names to be plural to match the style in the rest of the documentation.