### PR TITLE
Date.UTC is not a constructor, and does not accept Strings

### DIFF
--- a/sections/raw.js
+++ b/sections/raw.js
@@ -70,7 +70,7 @@ export default [
           knex.raw('accesslevel = ?', 1)
         )
         .orWhere(
-          knex.raw('updtime = ?', new Date.UTC('01-01-2016'))
+          knex.raw('updtime = ?', new Date('01-01-2016'))
         )
     `
   },


### PR DESCRIPTION
The `raw()` documentation fails to run because `Date.UTC is not a constructor`.

Here's what I found trying to figure out the intended call (Node 10.15.1):

```javascript
> new Date.UTC('01-01-2016')
// TypeError: Date.UTC is not a constructor
> Date.UTC('01-01-2016')
// NaN
> new Date('01-01-2016')
// 2016-01-01T05:00:00.000Z
```