### PR TITLE
dAdd note that for Postgres, float = real

### DIFF
--- a/sections/schema.js
+++ b/sections/schema.js
@@ -275,7 +275,7 @@ export default [
     type: "method",
     method: "float",
     example: "table.float(column, [precision], [scale])",
-    description: "Adds a float column, with optional precision (defaults to 8) and scale (defaults to 2).",
+    description: "Adds a float column, with optional precision (defaults to 8) and scale (defaults to 2).  Because PostgreSQL does not support precision, in that database Knex will ignore the precision argument and create a 32-bit float or \"real\" number column",
     children: [    ]
   },
   {


### PR DESCRIPTION
This commit corrects the missing documentation noted here: https://github.com/knex/knex/issues/2945 

It clarifies that because PostgreSQL doesn't support float precision, the Knex `float` method will result in a PostgreSQL "real" number column type.