### PR TITLE
Add entry for onDistinct

### DIFF
--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -108,6 +108,7 @@ export default class Sidebar extends Component {
           <li>&nbsp;&nbsp;– <a href="#Builder-clearCounters">clearCounters</a></li>
 
           <li>– <a href="#Builder-distinct">distinct</a></li>
+          <li>– <a href="#Builder-distinctOn">distinctOn</a></li>
           <li>– <a href="#Builder-groupBy">groupBy</a></li>
           <li>– <a href="#Builder-groupByRaw">groupByRaw</a></li>
           <li>– <a href="#Builder-orderBy">orderBy</a></li>

--- a/sections/builder.js
+++ b/sections/builder.js
@@ -1205,6 +1205,20 @@ export default [
   },
   {
     type: "method",
+    method: "distinctOn",
+    example: ".distinctOn([*columns])",
+    description: "PostgreSQL only. Adds a distinctOn clause to the query.",
+    children: [
+      {
+        type: "runnable",
+        content: `
+          knex('users').distinctOn('age')
+        `
+      }
+    ]
+  },
+  {
+    type: "method",
     method: "groupBy",
     example: ".groupBy(*names)",
     description: "Adds a group by clause to the query.",


### PR DESCRIPTION
Adds documentation for the PostgreSQL-only `onDistinct` which was added in https://github.com/knex/knex/pull/3513.