### PR TITLE
remove broken link from sidebar

### DIFF
--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -157,7 +157,6 @@ export default class Sidebar extends Component {
           Schema Builder
         </a>
         <ul className="toc_section">
-          <li>– <a href="#Schema-with">with</a></li>
           <li>– <a href="#Schema-withSchema">withSchema</a></li>
           <li>– <a href="#Schema-createTable">createTable</a></li>
           <li>– <a href="#Schema-renameTable">renameTable</a></li>


### PR DESCRIPTION
## Description
This PR removes a link `SchemaBuilder`->`with` from the sidebar. Nothing happens when we click this link and there is no `with` section in the documentation.


![image](https://user-images.githubusercontent.com/42166091/81667895-52c91280-945d-11ea-9282-38e7a49c8a53.png)
