### PR TITLE
docs(QueryBuilder): add method .clear(statement)

### DIFF
--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -103,11 +103,11 @@ export default class Sidebar extends Component {
 
           <li><b><a href="#Builder-clear">Clear Methods:</a></b></li>
           <li>&nbsp;&nbsp;– <a href="#Builder-clear">clear</a></li>
-          <li>&nbsp;&nbsp;– <a href="#Builder-clearSelect">clearSelect</a></li>
-          <li>&nbsp;&nbsp;– <a href="#Builder-clearWhere">clearWhere</a></li>
-          <li>&nbsp;&nbsp;– <a href="#Builder-clearOrder">clearOrder</a></li>
-          <li>&nbsp;&nbsp;– <a href="#Builder-clearHaving">clearHaving</a></li>
-          <li>&nbsp;&nbsp;– <a href="#Builder-clearCounters">clearCounters</a></li>
+          <li>&nbsp;&nbsp;– <a href="#Builder-clearSelect">clearSelect (deprecated)</a></li>
+          <li>&nbsp;&nbsp;– <a href="#Builder-clearWhere">clearWhere (deprecated)</a></li>
+          <li>&nbsp;&nbsp;– <a href="#Builder-clearOrder">clearOrder (deprecated)</a></li>
+          <li>&nbsp;&nbsp;– <a href="#Builder-clearHaving">clearHaving (deprecated)</a></li>
+          <li>&nbsp;&nbsp;– <a href="#Builder-clearCounters">clearCounters (deprecated)</a></li>
 
           <li>– <a href="#Builder-distinct">distinct</a></li>
           <li>– <a href="#Builder-distinctOn">distinctOn</a></li>

--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -102,6 +102,7 @@ export default class Sidebar extends Component {
           <li>&nbsp;&nbsp;– <a href="#Builder-havingRaw">havingRaw</a></li>
 
           <li><b><a href="#Builder-clear">Clear Methods:</a></b></li>
+          <li>&nbsp;&nbsp;– <a href="#Builder-clear">clear</a></li>
           <li>&nbsp;&nbsp;– <a href="#Builder-clearSelect">clearSelect</a></li>
           <li>&nbsp;&nbsp;– <a href="#Builder-clearWhere">clearWhere</a></li>
           <li>&nbsp;&nbsp;– <a href="#Builder-clearOrder">clearOrder</a></li>

--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -107,7 +107,7 @@ export default class Sidebar extends Component {
           <li>&nbsp;&nbsp;– <a href="#Builder-clearWhere">clearWhere (deprecated)</a></li>
           <li>&nbsp;&nbsp;– <a href="#Builder-clearOrder">clearOrder (deprecated)</a></li>
           <li>&nbsp;&nbsp;– <a href="#Builder-clearHaving">clearHaving (deprecated)</a></li>
-          <li>&nbsp;&nbsp;– <a href="#Builder-clearCounters">clearCounters (deprecated)</a></li>
+          <li>&nbsp;&nbsp;– <a href="#Builder-clearCounters">clearCounters</a></li>
 
           <li>– <a href="#Builder-distinct">distinct</a></li>
           <li>– <a href="#Builder-distinctOn">distinctOn</a></li>

--- a/sections/builder.js
+++ b/sections/builder.js
@@ -1107,7 +1107,7 @@ export default [
     type: "method",
     method: "clear",
     example: ".clear(statement)",
-    description: "Clears the specified operator from the query. Avalilables: 'select' alias 'columns', 'with', 'select', 'columns', 'where', 'union', 'join', 'group', 'order', 'having', 'limit', 'offset'",
+    description: "Clears the specified operator from the query. Avalilables: 'select' alias 'columns', 'with', 'select', 'columns', 'where', 'union', 'join', 'group', 'order', 'having', 'limit', 'offset', 'counter', 'counters'. Counter(s) alias for method .clearCounter()",
     children: [
       {
         type: "runnable",
@@ -1191,7 +1191,7 @@ export default [
     type: "method",
     method: "clearCounters",
     example: ".clearCounters()",
-    description: "Deprecated, use clear(statement). Clears all increments/decrements clauses from the query.",
+    description: "Clears all increments/decrements clauses from the query.",
     children: [
       {
         type: "runnable",

--- a/sections/builder.js
+++ b/sections/builder.js
@@ -1121,7 +1121,7 @@ export default [
     type: "method",
     method: "clearSelect",
     example: ".clearSelect()",
-    description: "Clears all select clauses from the query, excluding subqueries.",
+    description: "Deprecated, use clear(statement). Clears all select clauses from the query, excluding subqueries.",
     children: [
       {
         type: "runnable",
@@ -1135,7 +1135,7 @@ export default [
     type: "method",
     method: "clearWhere",
     example: ".clearWhere()",
-    description: "Clears all where clauses from the query, excluding subqueries.",
+    description: "Deprecated, use clear(statement). Clears all where clauses from the query, excluding subqueries.",
     children: [
       {
         type: "runnable",
@@ -1149,7 +1149,7 @@ export default [
     type: "method",
     method: "clearGroup",
     example: ".clearGroup()",
-    description: "Clears all group clauses from the query, excluding subqueries.",
+    description: "Deprecated, use clear(statement). Clears all group clauses from the query, excluding subqueries.",
     children: [
       {
         type: "runnable",
@@ -1163,7 +1163,7 @@ export default [
     type: "method",
     method: "clearOrder",
     example: ".clearOrder()",
-    description: "Clears all order clauses from the query, excluding subqueries.",
+    description: "Deprecated, use clear(statement). Clears all order clauses from the query, excluding subqueries.",
     children: [
       {
         type: "runnable",
@@ -1177,7 +1177,7 @@ export default [
     type: "method",
     method: "clearHaving",
     example: ".clearHaving()",
-    description: "Clears all having clauses from the query, excluding subqueries.",
+    description: "Deprecated, use clear(statement). Clears all having clauses from the query, excluding subqueries.",
     children: [
       {
         type: "runnable",
@@ -1191,7 +1191,7 @@ export default [
     type: "method",
     method: "clearCounters",
     example: ".clearCounters()",
-    description: "Clears all increments/decrements clauses from the query.",
+    description: "Deprecated, use clear(statement). Clears all increments/decrements clauses from the query.",
     children: [
       {
         type: "runnable",

--- a/sections/builder.js
+++ b/sections/builder.js
@@ -1105,6 +1105,20 @@ export default [
   },
   {
     type: "method",
+    method: "clear",
+    example: ".clear(statement)",
+    description: "Clears the specified operator from the query. Avalilables: 'select' alias 'columns', 'with', 'select', 'columns', 'where', 'union', 'join', 'group', 'order', 'having', 'limit', 'offset'",
+    children: [
+      {
+        type: "runnable",
+        content: `
+        knex.select('email', 'name').from('users').where('id', '<', 10).clear('select').clear('where')
+        `
+      }
+    ]
+  },
+  {
+    type: "method",
     method: "clearSelect",
     example: ".clearSelect()",
     description: "Clears all select clauses from the query, excluding subqueries.",

--- a/sections/builder.js
+++ b/sections/builder.js
@@ -1121,7 +1121,7 @@ export default [
     type: "method",
     method: "clearSelect",
     example: ".clearSelect()",
-    description: "Deprecated, use clear(statement). Clears all select clauses from the query, excluding subqueries.",
+    description: "Deprecated, use clear('select'). Clears all select clauses from the query, excluding subqueries.",
     children: [
       {
         type: "runnable",
@@ -1135,7 +1135,7 @@ export default [
     type: "method",
     method: "clearWhere",
     example: ".clearWhere()",
-    description: "Deprecated, use clear(statement). Clears all where clauses from the query, excluding subqueries.",
+    description: "Deprecated, use clear('where'). Clears all where clauses from the query, excluding subqueries.",
     children: [
       {
         type: "runnable",
@@ -1149,7 +1149,7 @@ export default [
     type: "method",
     method: "clearGroup",
     example: ".clearGroup()",
-    description: "Deprecated, use clear(statement). Clears all group clauses from the query, excluding subqueries.",
+    description: "Deprecated, use clear('group'). Clears all group clauses from the query, excluding subqueries.",
     children: [
       {
         type: "runnable",
@@ -1163,7 +1163,7 @@ export default [
     type: "method",
     method: "clearOrder",
     example: ".clearOrder()",
-    description: "Deprecated, use clear(statement). Clears all order clauses from the query, excluding subqueries.",
+    description: "Deprecated, use clear('order'). Clears all order clauses from the query, excluding subqueries.",
     children: [
       {
         type: "runnable",
@@ -1177,7 +1177,7 @@ export default [
     type: "method",
     method: "clearHaving",
     example: ".clearHaving()",
-    description: "Deprecated, use clear(statement). Clears all having clauses from the query, excluding subqueries.",
+    description: "Deprecated, use clear('having'). Clears all having clauses from the query, excluding subqueries.",
     children: [
       {
         type: "runnable",


### PR DESCRIPTION
`.clear(statement)` Clears the specified operator from the query. Avalilables: 'select' alias 'columns', 'with', 'select', 'columns', 'where', 'union', 'join', 'group', 'order', 'having', 'limit', 'offset'

Ref: https://github.com/knex/knex/pull/4051