### PR TITLE
Add table.double to documentation

### DIFF
--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -181,6 +181,7 @@ export default class Sidebar extends Component {
           <li>– <a href="#Schema-text">text</a></li>
           <li>– <a href="#Schema-string">string</a></li>
           <li>– <a href="#Schema-float">float</a></li>
+          <li>– <a href="#Schema-double">double</a></li>
           <li>– <a href="#Schema-decimal">decimal</a></li>
           <li>– <a href="#Schema-boolean">boolean</a></li>
           <li>– <a href="#Schema-date">date</a></li>

--- a/sections/schema.js
+++ b/sections/schema.js
@@ -280,6 +280,13 @@ export default [
   },
   {
     type: "method",
+    method: "double",
+    example: "table.double(column, [precision], [scale])",
+    description: "Adds a double column, with optional precision (defaults to 8) and scale (defaults to 2). Not supported on Postgres",
+    children: [    ]
+  },
+  {
+    type: "method",
     method: "decimal",
     example: "table.decimal(column, [precision], [scale])",
     description: "Adds a decimal column, with optional precision (defaults to 8) and scale (defaults to 2). Specifying NULL as precision creates a decimal column that can store numbers of any precision and scale. (Only supported for Oracle, SQLite, Postgres)",

--- a/sections/schema.js
+++ b/sections/schema.js
@@ -282,7 +282,7 @@ export default [
     type: "method",
     method: "double",
     example: "table.double(column, [precision], [scale])",
-    description: "Adds a double column, with optional precision (defaults to 8) and scale (defaults to 2). Not supported on Postgres",
+    description: "Adds a double column, with optional precision (defaults to 8) and scale (defaults to 2). In SQLite/MSSQL this is a float with no precision/scale; In PostgreSQL this is a double precision; In Oracle this is a number with matching precision/scale.",
     children: [    ]
   },
   {


### PR DESCRIPTION
Hello!

💁‍♀️ This PR adds documentation for `double` columns to the Schema Builder documentation.