### PR TITLE
Fix havingRaw signature

### DIFF
--- a/sections/builder.js
+++ b/sections/builder.js
@@ -1469,7 +1469,7 @@ export default [
   {
     type: "method",
     method: "havingRaw",
-    example: ".havingRaw(column, operator, value)",
+    example: ".havingRaw(sql, [bindings])",
     description: "Adds a havingRaw clause to the query.",
     children: [
       {


### PR DESCRIPTION
Hi 👋 

Just noticed the signature is actually `havingRaw(sql, bindings)`: [code](https://github.com/knex/knex/blob/8d43019873a2d9a1072c8a2d81a6f5e8801e57cc/lib/query/builder.js#L872).