### PR TITLE
columnInfo: Fix bulleted list rendering

### DIFF
--- a/sections/builder.js
+++ b/sections/builder.js
@@ -2671,7 +2671,7 @@ export default [
     type: "method",
     method: "columnInfo",
     example: ".columnInfo([columnName])",
-    description: "Returns an object with the column info about the current table, or an individual column if one is passed, returning an object with the following keys:*   **defaultValue**: the default value for the column*   **type**: the column type*   **maxLength**: the max length set for the column*   **nullable**: whether the column may be null",
+    description: "Returns an object with the column info about the current table, or an individual column if one is passed, returning an object with the following keys:\n*   **defaultValue**: the default value for the column\n*   **type**: the column type\n*   **maxLength**: the max length set for the column\n*   **nullable**: whether the column may be null",
     children: [
       {
         type: "code",


### PR DESCRIPTION
Before, it was rendered as a run-on with literal asterisks.

Now, it renders as a bulleted list.

## Screenshots
### Before
![before - Screen Shot 2021-03-01 at 19 44 43](https://user-images.githubusercontent.com/29010/109579317-ada02900-7ac6-11eb-81d0-69452d3e95ee.png)

### After
![after - Screen Shot 2021-03-01 at 19 44 51](https://user-images.githubusercontent.com/29010/109579328-b133b000-7ac6-11eb-9a3a-3a465b4f8f8a.png)
