### PR TITLE
fix(docs): migration from mssql to tedious

### DIFF
--- a/sections/installation.js
+++ b/sections/installation.js
@@ -17,7 +17,7 @@ export default [
   },
   {
     type: "text",
-    content: "The primary target environment for Knex is Node.js, you will need to install the `knex` library, and then install the appropriate database library: [`pg`](https://github.com/brianc/node-postgres) for PostgreSQL and Amazon Redshift, [`mysql`](https://github.com/felixge/node-mysql) for MySQL or MariaDB, [`sqlite3`](https://github.com/mapbox/node-sqlite3) for SQLite3, or [`mssql`](https://github.com/patriksimek/node-mssql) for MSSQL."
+    content: "The primary target environment for Knex is Node.js, you will need to install the `knex` library, and then install the appropriate database library: [`pg`](https://github.com/brianc/node-postgres) for PostgreSQL and Amazon Redshift, [`mysql`](https://github.com/felixge/node-mysql) for MySQL or MariaDB, [`sqlite3`](https://github.com/mapbox/node-sqlite3) for SQLite3, or [`tedious`](https://github.com/tediousjs/tedious) for MSSQL."
   },
   {
     type: "code",
@@ -30,7 +30,7 @@ export default [
       $ npm install mysql
       $ npm install mysql2
       $ npm install oracledb
-      $ npm install mssql
+      $ npm install tedious
     `
   },
   {


### PR DESCRIPTION
Knex has migrated to `tedious` from `mssql` package but the docs still refers to `mssql`. This PR contains a fix for that.

**Whats upgrading docs are saying:**

https://github.com/knex/knex/blob/master/UPGRADING.md

> MSSQL driver was completely reworked in order to address the multitude of connection pool, error handling and performance issues. Since the new implementation uses tedious library directly instead of mssql, please replace mssql with tedious in your dependencies if you are using a MSSQL database.