### PR TITLE
fixed typescript example of extending QueryBuilder

### DIFF
--- a/sections/builder.js
+++ b/sections/builder.js
@@ -2814,8 +2814,11 @@ export default [
       import { Knex } from 'knex';
 
       declare module 'knex' {
-        interface QueryBuilder {
-        customSelect<TRecord, TResult>(value: number): Knex.QueryBuilder<TRecord, TResult>;
+        namespace Knex {
+          interface QueryBuilder {
+            customSelect<TRecord, TResult>(value: number): Knex.QueryBuilder<TRecord, TResult>;
+          }
+        }
       }
     `
   },


### PR DESCRIPTION
The way an extension to the QueryBuilder is defined in typescript changed with knex 0.95, as evidenced here: https://github.com/knex/knex/blob/master/UPGRADING.md#upgrading-to-version-0950

This is just reflecting that change in the documentation, to spare others my pain when I couldn't understand why following the doc failed ;-)