### PR TITLE
Fix example for batch insert with conflict merge

### DIFF
--- a/sections/builder.js
+++ b/sections/builder.js
@@ -1738,11 +1738,11 @@ export default [
         type: "runnable",
         content: `
           knex('tableName')
-            .insert(
+            .insert([
               { email: "john@example.com", name: "John Doe" },
               { email: "jane@example.com", name: "Jane Doe" },
               { email: "alex@example.com", name: "Alex Doe" },
-            )
+            ])
             .onConflict('email')
             .merge()
         `


### PR DESCRIPTION
Hi,

The query documentation states that [conflict merge](http://knexjs.org/#Builder-merge) works for batch insert too, but the example is not quite right.

This is the current example
```js
knex('tableName')
  .insert(
    { email: "john@example.com", name: "John Doe" },
    { email: "jane@example.com", name: "Jane Doe" },
    { email: "alex@example.com", name: "Alex Doe" },
  )
  .onConflict('email')
  .merge()
```
outputs sql for a single insert:
```sql
insert into `tableName` (`email`, `name`) values ('john@example.com', 'John Doe') on duplicate key update `email` = values(`email`), `name` = values(`name`)
```

A better example would have been (note the array of inserted objects):
```js
knex('tableName')
  .insert([
    { email: "john@example.com", name: "John Doe" },
    { email: "jane@example.com", name: "Jane Doe" },
    { email: "alex@example.com", name: "Alex Doe" },
  ])
  .onConflict('email')
  .merge()
```
which gives the intended sql
```sql
insert into `tableName` (`email`, `name`) values ('john@example.com', 'John Doe'), ('jane@example.com', 'Jane Doe'), ('alex@example.com', 'Alex Doe') on duplicate key update `email` = values(`email`), `name` = values(`name`)
```