### PR TITLE
Fix typo in sections/esm-interop.js

### DIFF
--- a/sections/esm-interop.js
+++ b/sections/esm-interop.js
@@ -143,7 +143,7 @@ export default [
       },
       {
         type: "text",
-        content: `Seed an migration files need to follow Knex conventions`
+        content: `Seed and migration files need to follow Knex conventions`
       },
       {
         type: "code",


### PR DESCRIPTION
Hi!

Found a typo while reading the docs and trying to work on a small PR for another project. ~Not sure if I should have run `yarn build`, or just fixed the file in the sections folder...~ scratch that, had a look at another PR fixing a typo and it changed only the file under `section`, so I did the same here :+1: 

Thanks!
Bruno