### PR TITLE
Add documentation for partitionBy and clean up some spacings and child assigns

### DIFF
--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -144,6 +144,10 @@ export default class Sidebar extends Component {
           <li>– <a href="#Builder-pluck">pluck</a></li>
           <li>– <a href="#Builder-first">first</a></li>
           <li>– <a href="#Builder-clone">clone</a></li>
+          <li>– <a href="#Builder-rank">rank</a></li>
+          <li>– <a href="#Builder-denseRank">denseRank</a></li>
+          <li>– <a href="#Builder-rowNumber">rowNumber</a></li>
+          <li>– <a href="#Builder-partitionBy">partitionBy</a></li>
           <li>– <a href="#Builder-modify">modify</a></li>
           <li>– <a href="#Builder-columnInfo">columnInfo</a></li>
           <li>– <a href="#Builder-debug">debug</a></li>
@@ -242,12 +246,12 @@ export default class Sidebar extends Component {
         </ul>
 
         <a className="toc_title" href="#Ref">
-         Ref
+          Ref
         </a>
         <ul className="toc_section">
-         <li>– <a href="#Ref-Usage">Usage</a></li>
-         <li>– <a href="#Ref-withSchema">withSchema</a></li>
-         <li>– <a href="#Ref-alias">alias</a></li>
+          <li>– <a href="#Ref-Usage">Usage</a></li>
+          <li>– <a href="#Ref-withSchema">withSchema</a></li>
+          <li>– <a href="#Ref-alias">alias</a></li>
         </ul>
 
 
@@ -287,23 +291,23 @@ export default class Sidebar extends Component {
 
         <ul className="toc_section">
           <li><a href="#Migrations-CLI"><b>CLI</b></a></li>
-            <li>– <a href="#Migrations-CLI">Migrations</a></li>
-            <li>– <a href="#Seeds-CLI">Seed files</a></li>
-            <li>– <a href="#knexfile">knexfile.js</a></li>
-            <li>– <a href="#esm-interop">esm</a></li>
+          <li>– <a href="#Migrations-CLI">Migrations</a></li>
+          <li>– <a href="#Seeds-CLI">Seed files</a></li>
+          <li>– <a href="#knexfile">knexfile.js</a></li>
+          <li>– <a href="#esm-interop">esm</a></li>
           <li><a href="#Migrations-API"><b>Migration API</b></a></li>
-            <li>– <a href="#Migrations-make">make</a></li>
-            <li>– <a href="#Migrations-latest">latest</a></li>
-            <li>– <a href="#Migrations-rollback">rollback</a></li>
-            <ii>- <a href="#Migrations-up">up</a></ii>
-            <ii>- <a href="#Migrations-down">down</a></ii>
-            <li>– <a href="#Migrations-currentVersion">currentVersion</a></li>
-            <li>– <a href="#Migrations-list">list</a></li>
-            <li>– <a href="#Migrations-unlock">unlock</a></li>
+          <li>– <a href="#Migrations-make">make</a></li>
+          <li>– <a href="#Migrations-latest">latest</a></li>
+          <li>– <a href="#Migrations-rollback">rollback</a></li>
+          <ii>- <a href="#Migrations-up">up</a></ii>
+          <ii>- <a href="#Migrations-down">down</a></ii>
+          <li>– <a href="#Migrations-currentVersion">currentVersion</a></li>
+          <li>– <a href="#Migrations-list">list</a></li>
+          <li>– <a href="#Migrations-unlock">unlock</a></li>
           <li><a href="#Notes-about-locks"><b>Notes about locks</b></a></li>
           <li><a href="#Seeds-API"><b>Seed API</b></a></li>
-            <li>– <a href="#Seeds-make">make</a></li>
-            <li>– <a href="#Seeds-run">run</a></li>
+          <li>– <a href="#Seeds-make">make</a></li>
+          <li>– <a href="#Seeds-run">run</a></li>
         </ul>
 
         <a className="toc_title" href="#support">

--- a/sections/builder.js
+++ b/sections/builder.js
@@ -2483,169 +2483,219 @@ export default [
     type: "method",
     method: "denseRank",
     example: ".denseRank(alias, ~mixed~)",
-    children: [    ]
-  },
-  {
-    type: "text",
-    content: "Add a dense_rank() call to your query. For all the following queries, alias can be set to a falsy value if not needed."
-  },
-  {
-    type: "text",
-    content: "String Syntax — .denseRank(alias, orderByClause, [partitionByClause]) :",
-  },
-  {
-    type: "runnable",
-    content: `
-      knex('users').select('*').denseRank('alias_name', 'email', 'firstName')
-    `
-  },
-  {
-    type: "text",
-    content: "It also accepts arrays of strings as argument :",
-  },
-  {
-    type: "runnable",
-    content: `
-      knex('users').select('*').denseRank('alias_name', ['email', 'address'], ['firstName', 'lastName'])
-    `
-  },
-  {
-    type: "text",
-    content: "Raw Syntax — .denseRank(alias, rawQuery) :",
-  },
-  {
-    type: "runnable",
-    content: `
-      knex('users').select('*').denseRank('alias_name', knex.raw('order by ??', ['email']))
-    `
-  },
-  {
-    type: "text",
-    content: "Function Syntax — .denseRank(alias, function) :",
-  },
-  {
-    type: "text",
-    content: "Use orderBy() and partitionBy() (both chainable) to build your query :",
-  },
-  {
-    type: "runnable",
-    content: `
-      knex('users').select('*').denseRank('alias_name', function() {
-        this.orderBy('email').partitionBy('firstName')
-      })
-    `
+    children: [
+      {
+        type: "text",
+        content: "Add a dense_rank() call to your query. For all the following queries, alias can be set to a falsy value if not needed."
+      },
+      {
+        type: "text",
+        content: "String Syntax — .denseRank(alias, orderByClause, [partitionByClause]) :",
+      },
+      {
+        type: "runnable",
+        content: `
+          knex('users').select('*').denseRank('alias_name', 'email', 'firstName')
+        `
+      },
+      {
+        type: "text",
+        content: "It also accepts arrays of strings as argument :",
+      },
+      {
+        type: "runnable",
+        content: `
+          knex('users').select('*').denseRank('alias_name', ['email', 'address'], ['firstName', 'lastName'])
+        `
+      },
+      {
+        type: "text",
+        content: "Raw Syntax — .denseRank(alias, rawQuery) :",
+      },
+      {
+        type: "runnable",
+        content: `
+          knex('users').select('*').denseRank('alias_name', knex.raw('order by ??', ['email']))
+        `
+      },
+      {
+        type: "text",
+        content: "Function Syntax — .denseRank(alias, function) :",
+      },
+      {
+        type: "text",
+        content: "Use orderBy() and partitionBy() (both chainable) to build your query :",
+      },
+      {
+        type: "runnable",
+        content: `
+          knex('users').select('*').denseRank('alias_name', function() {
+            this.orderBy('email').partitionBy('firstName')
+          })
+        `
+      }
+    ]
   },
   {
     type: "method",
     method: "rank",
     example: ".rank(alias, ~mixed~)",
-    children: [    ]
-  },
-  {
-    type: "text",
-    content: "Add a rank() call to your query. For all the following queries, alias can be set to a falsy value if not needed."
-  },
-  {
-    type: "text",
-    content: "String Syntax — .rank(alias, orderByClause, [partitionByClause]) :",
-  },
-  {
-    type: "runnable",
-    content: `
-      knex('users').select('*').rank('alias_name', 'email', 'firstName')
-    `
-  },
-  {
-    type: "text",
-    content: "It also accepts arrays of strings as argument :",
-  },
-  {
-    type: "runnable",
-    content: `
-      knex('users').select('*').rank('alias_name', ['email', 'address'], ['firstName', 'lastName'])
-    `
-  },
-  {
-    type: "text",
-    content: "Raw Syntax — .rank(alias, rawQuery) :",
-  },
-  {
-    type: "runnable",
-    content: `
-      knex('users').select('*').rank('alias_name', knex.raw('order by ??', ['email']))
-    `
-  },
-  {
-    type: "text",
-    content: "Function Syntax — .rank(alias, function) :",
-  },
-  {
-    type: "text",
-    content: "Use orderBy() and partitionBy() (both chainable) to build your query :",
-  },
-  {
-    type: "runnable",
-    content: `
-      knex('users').select('*').rank('alias_name', function() {
-        this.orderBy('email').partitionBy('firstName')
-      })
-    `
+    children: [
+      {
+        type: "text",
+        content: "Add a rank() call to your query. For all the following queries, alias can be set to a falsy value if not needed."
+      },
+      {
+        type: "text",
+        content: "String Syntax — .rank(alias, orderByClause, [partitionByClause]) :",
+      },
+      {
+        type: "runnable",
+        content: `
+          knex('users').select('*').rank('alias_name', 'email', 'firstName')
+        `
+      },
+      {
+        type: "text",
+        content: "It also accepts arrays of strings as argument :",
+      },
+      {
+        type: "runnable",
+        content: `
+          knex('users').select('*').rank('alias_name', ['email', 'address'], ['firstName', 'lastName'])
+        `
+      },
+      {
+        type: "text",
+        content: "Raw Syntax — .rank(alias, rawQuery) :",
+      },
+      {
+        type: "runnable",
+        content: `
+          knex('users').select('*').rank('alias_name', knex.raw('order by ??', ['email']))
+        `
+      },
+      {
+        type: "text",
+        content: "Function Syntax — .rank(alias, function) :",
+      },
+      {
+        type: "text",
+        content: "Use orderBy() and partitionBy() (both chainable) to build your query :",
+      },
+      {
+        type: "runnable",
+        content: `
+          knex('users').select('*').rank('alias_name', function() {
+            this.orderBy('email').partitionBy('firstName')
+          })
+        `
+      }
+    ]
   },
   {
     type: "method",
     method: "rowNumber",
     example: ".rowNumber(alias, ~mixed~)",
-    children: [    ]
+    children: [
+      {
+        type: "text",
+        content: "Add a row_number() call to your query. For all the following queries, alias can be set to a falsy value if not needed."
+      },
+      {
+        type: "text",
+        content: "String Syntax — .rowNumber(alias, orderByClause, [partitionByClause]) :",
+      },
+      {
+        type: "runnable",
+        content: `
+          knex('users').select('*').rowNumber('alias_name', 'email', 'firstName')
+        `
+      },
+      {
+        type: "text",
+        content: "It also accepts arrays of strings as argument :",
+      },
+      {
+        type: "runnable",
+        content: `
+          knex('users').select('*').rowNumber('alias_name', ['email', 'address'], ['firstName', 'lastName'])
+        `
+      },
+      {
+        type: "text",
+        content: "Raw Syntax — .rowNumber(alias, rawQuery) :",
+      },
+      {
+        type: "runnable",
+        content: `
+          knex('users').select('*').rowNumber('alias_name', knex.raw('order by ??', ['email']))
+        `
+      },
+      {
+        type: "text",
+        content: "Function Syntax — .rowNumber(alias, function) :",
+      },
+      {
+        type: "text",
+        content: "Use orderBy() and partitionBy() (both chainable) to build your query :",
+      },
+      {
+        type: "runnable",
+        content: `
+          knex('users').select('*').rowNumber('alias_name', function() {
+            this.orderBy('email').partitionBy('firstName')
+          })
+        `
+      }
+    ]
   },
   {
-    type: "text",
-    content: "Add a row_number() call to your query. For all the following queries, alias can be set to a falsy value if not needed."
-  },
-  {
-    type: "text",
-    content: "String Syntax — .rowNumber(alias, orderByClause, [partitionByClause]) :",
-  },
-  {
-    type: "runnable",
-    content: `
-      knex('users').select('*').rowNumber('alias_name', 'email', 'firstName')
-    `
-  },
-  {
-    type: "text",
-    content: "It also accepts arrays of strings as argument :",
-  },
-  {
-    type: "runnable",
-    content: `
-      knex('users').select('*').rowNumber('alias_name', ['email', 'address'], ['firstName', 'lastName'])
-    `
-  },
-  {
-    type: "text",
-    content: "Raw Syntax — .rowNumber(alias, rawQuery) :",
-  },
-  {
-    type: "runnable",
-    content: `
-      knex('users').select('*').rowNumber('alias_name', knex.raw('order by ??', ['email']))
-    `
-  },
-  {
-    type: "text",
-    content: "Function Syntax — .rowNumber(alias, function) :",
-  },
-  {
-    type: "text",
-    content: "Use orderBy() and partitionBy() (both chainable) to build your query :",
-  },
-  {
-    type: "runnable",
-    content: `
-      knex('users').select('*').rowNumber('alias_name', function() {
-        this.orderBy('email').partitionBy('firstName')
-      })
-    `
+    type: "method",
+    method: "partitionBy",
+    example: ".partitionBy(column, direction)",
+    description: "Partitions rowNumber, denseRank, rank after a specific column or columns. If direction is not supplied it will default to ascending order.",
+    children: [
+      {
+        type: "text",
+        content: "No direction sort :",
+      },
+      {
+        type: "code",
+        language: "js",
+        content: `
+        knex('users').select('*').rowNumber('alias_name', function() {
+          this.partitionBy('firstName');
+        });
+        `
+      },
+      {
+        type: "text",
+        content: "With direction sort :",
+      },
+      {
+        type: "code",
+        language: "js",
+        content: `
+        knex('users').select('*').rowNumber('alias_name', function() {
+          this.partitionBy('firstName', 'desc');
+        });
+        `
+      },
+      {
+        type: "text",
+        content: "With multiobject :",
+      },
+      {
+        type: "code",
+        language: "js",
+        content: `
+        knex('users').select('*').rowNumber('alias_name', function() {
+          this.partitionBy([{ column: 'firstName', order: 'asc' }, { column: 'lastName', order: 'desc' }]);
+        });
+        `
+      }
+    ]
   },
   {
     type: "method",


### PR DESCRIPTION
Add documentation for partitionBy as some new changes adding functions to use direction sorting in `rank`, `denseRank`, `rowNumber` as well as adding the quick navigation for all of them.

knex pr: [link](https://github.com/knex/knex/pull/4602) 