### PR TITLE
Add dropSchema and dropSchemaIfExists doc (#4713)

### DIFF
--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -178,6 +178,8 @@ export default class Sidebar extends Component {
           <li>– <a href="#Schema-generateDdlCommands">generateDdlCommands</a></li>
           <li>– <a href="#Schema-raw">raw</a></li>
           <li>– <a href="#Schema-queryContext">queryContext</a></li>
+          <li>– <a href="#Schema-dropSchema">dropSchema</a></li>
+          <li>– <a href="#Schema-dropSchemaIfExists">dropSchemaIfExists</a></li>
           <li><b><a href="#Schema-Building">Schema Building:</a></b></li>
           <li>– <a href="#Schema-dropColumn">dropColumn</a></li>
           <li>– <a href="#Schema-dropColumns">dropColumns</a></li>

--- a/sections/schema.js
+++ b/sections/schema.js
@@ -211,6 +211,42 @@ export default [
     ]
   },
   {
+    type: "method",
+    method: "dropSchema",
+    example: "knex.schema.dropSchema(schemaName, [cascade])",
+    description: "Drop a schema, specified by the schema's name, with optional cascade option (default to false). Only supported by PostgreSQL.",
+    children: [
+      {
+        type: 'code',
+        language: 'js',
+        content: `
+          //drop schema 'public'
+          knex.schema.dropSchema('public')
+          //drop schema 'public' cascade
+          knex.schema.dropSchema('public', true)
+        `
+      }
+    ]
+  },
+  {
+    type: "method",
+    method: "dropSchemaIfExists",
+    example: "knex.schema.dropSchemaIfExists(schemaName, [cascade])",
+    description: "Drop a schema conditionally if the schema exists, specified by the schema's name, with optional cascade option (default to false). Only supported by PostgreSQL.",
+    children: [
+      {
+        type: 'code',
+        language: 'js',
+        content: `
+          //drop schema if exists 'public'
+          knex.schema.dropSchema('public')
+          //drop schema if exists 'public' cascade
+          knex.schema.dropSchema('public', true)
+        `
+      }
+    ]
+  },
+  {
     type: "heading",
     size: "md",
     content: "Schema Building:",

--- a/sections/schema.js
+++ b/sections/schema.js
@@ -239,9 +239,9 @@ export default [
         language: 'js',
         content: `
           //drop schema if exists 'public'
-          knex.schema.dropSchema('public')
+          knex.schema.dropSchemaIfExists('public')
           //drop schema if exists 'public' cascade
-          knex.schema.dropSchema('public', true)
+          knex.schema.dropSchemaIfExists('public', true)
         `
       }
     ]


### PR DESCRIPTION
I add cascade option for dropSchema here https://github.com/knex/knex/pull/4713, but as I can see, dropSchema and dropSchemaIfExists isn't documented, I add doc for the two methods.