### PR TITLE
Migrations: Fix code formatting

### DIFF
--- a/sections/migrations.js
+++ b/sections/migrations.js
@@ -608,7 +608,7 @@ export default [
                 down(knex) { /* ... */ }
               }
           }
-        },
+        }
       }
 
       // pass an instance of your migration source as knex config


### PR DESCRIPTION
Space was messing with syntax highlighting, and a comma was removed