### PR TITLE
skiplocked and nowait in mariadb

### DIFF
--- a/sections/builder.js
+++ b/sections/builder.js
@@ -2054,7 +2054,7 @@ export default [
     type: "method",
     method: "skipLocked",
     example: ".skipLocked()",
-    description: "MySQL 8.0+ and PostgreSQL 9.5+ only. This method can be used after a lock mode has been specified with either forUpdate or forShare, and will cause the query to skip any locked rows, returning an empty set if none are available.",
+    description: "MySQL 8.0+, MariaDB-10.6+ and PostgreSQL 9.5+ only. This method can be used after a lock mode has been specified with either forUpdate or forShare, and will cause the query to skip any locked rows, returning an empty set if none are available.",
     children: [
       {
         type: "runnable",
@@ -2071,7 +2071,7 @@ export default [
     type: "method",
     method: "noWait",
     example: ".noWait()",
-    description: "MySQL 8.0+ and PostgreSQL 9.5+ only. This method can be used after a lock mode has been specified with either forUpdate or forShare, and will cause the query to fail immediately if any selected rows are currently locked.",
+    description: "MySQL 8.0+, MariaDB-10.3+ and PostgreSQL 9.5+ only. This method can be used after a lock mode has been specified with either forUpdate or forShare, and will cause the query to fail immediately if any selected rows are currently locked.",
     children: [
       {
         type: "runnable",


### PR DESCRIPTION
Nowait was added in 10.3 - https://mariadb.com/kb/en/wait-and-nowait/

skiplocked was added in 10.6 - https://mariadb.com/kb/en/select/#skip-locked