### PR TITLE
href Schema.index vs column.index

### DIFF
--- a/sections/schema.js
+++ b/sections/schema.js
@@ -744,6 +744,7 @@ export default [
   {
     type: "method",
     method: "index",
+    href: "Schema-table-index",
     example: "table.index(columns, [indexName], options=({[indexType: string], [storageEngineIndexType: 'btree'|'hash'], [predicate: QueryBuilder]}))",
     description: "Adds an index to a table over the given columns. A default index name using the columns is used unless indexName is specified. In MySQL, the storage engine index type may be 'btree' or 'hash' index types, more info in Index Options section : https://dev.mysql.com/doc/refman/8.0/en/create-index.html. The indexType can be optionally specified for PostgreSQL and MySQL. Amazon Redshift does not allow creating an index. In PostgreSQL, SQLite and MSSQL a partial index can be specified by setting a 'where' predicate.",
     children: [


### PR DESCRIPTION
Currently both functions link to Schema.index() and the column.index() function isn't linkable