### PR TITLE
add docs aout smallint, integer, biginteger, tinyint, mediumint

### DIFF
--- a/sections/schema.js
+++ b/sections/schema.js
@@ -496,15 +496,36 @@ export default [
   {
     type: "method",
     method: "integer",
-    example: "table.integer(name)",
-    description: "Adds an integer column.",
+    example: "table.integer(name, length)",
+    description: "Adds an integer column. On PostgreSQL you cannot adjust the lenght, you need to use other option such as bigInteger, etc",
     children: [    ]
   },
   {
     type: "method",
     method: "bigInteger",
-    example: "table.bigInteger(name)",
+    example: "table.bigInteger(name, length)",
     description: "In MySQL or PostgreSQL, adds a bigint column, otherwise adds a normal integer. Note that bigint data is returned as a string in queries because JavaScript may be unable to parse them without loss of precision.",
+    children: [    ]
+  },
+  {
+    type: "method",
+    method: "tinyint",
+    example: "table.smallint(name, length)",
+    description: "Adds an tinyint column",
+    children: [    ]
+  },
+  {
+    type: "method",
+    method: "smallint",
+    example: "table.smallint(name, length)",
+    description: "Adds an smallint column",
+    children: [    ]
+  },
+  {
+    type: "method",
+    method: "smallint",
+    example: "table.mediumint(name, length)",
+    description: "Adds an mediumint column",
     children: [    ]
   },
   {

--- a/sections/schema.js
+++ b/sections/schema.js
@@ -530,7 +530,7 @@ export default [
   },
   {
     type: "method",
-    method: "mediumint",
+    method: "bigint",
     example: "table.bigint(name)",
     description: "Adds a bigint column",
     children: [    ]

--- a/sections/schema.js
+++ b/sections/schema.js
@@ -510,7 +510,7 @@ export default [
   {
     type: "method",
     method: "tinyint",
-    example: "table.smallint(name, length)",
+    example: "table.tinyint(name, length)",
     description: "Adds an tinyint column",
     children: [    ]
   },
@@ -523,7 +523,7 @@ export default [
   },
   {
     type: "method",
-    method: "smallint",
+    method: "mediumint",
     example: "table.mediumint(name, length)",
     description: "Adds an mediumint column",
     children: [    ]

--- a/sections/schema.js
+++ b/sections/schema.js
@@ -497,13 +497,13 @@ export default [
     type: "method",
     method: "integer",
     example: "table.integer(name, length)",
-    description: "Adds an integer column. On PostgreSQL you cannot adjust the lenght, you need to use other option such as bigInteger, etc",
+    description: "Adds an integer column. On PostgreSQL you cannot adjust the length, you need to use other option such as bigInteger, etc",
     children: [    ]
   },
   {
     type: "method",
     method: "bigInteger",
-    example: "table.bigInteger(name, length)",
+    example: "table.bigInteger(name)",
     description: "In MySQL or PostgreSQL, adds a bigint column, otherwise adds a normal integer. Note that bigint data is returned as a string in queries because JavaScript may be unable to parse them without loss of precision.",
     children: [    ]
   },
@@ -511,21 +511,28 @@ export default [
     type: "method",
     method: "tinyint",
     example: "table.tinyint(name, length)",
-    description: "Adds an tinyint column",
+    description: "Adds a tinyint column",
     children: [    ]
   },
   {
     type: "method",
     method: "smallint",
-    example: "table.smallint(name, length)",
-    description: "Adds an smallint column",
+    example: "table.smallint(name)",
+    description: "Adds a smallint column",
     children: [    ]
   },
   {
     type: "method",
     method: "mediumint",
-    example: "table.mediumint(name, length)",
-    description: "Adds an mediumint column",
+    example: "table.mediumint(name)",
+    description: "Adds a mediumint column",
+    children: [    ]
+  },
+  {
+    type: "method",
+    method: "mediumint",
+    example: "table.bigint(name)",
+    description: "Adds a bigint column",
     children: [    ]
   },
   {


### PR DESCRIPTION
Related issue https://github.com/knex/knex/issues/4849, added some example after looking at this test case.

```
            table.integer('integer_column', 5);
            table.tinyint('tinyint_column', 5);
            table.smallint('smallint_column', 5);
            table.mediumint('mediumint_column', 5);
            table.bigint('bigint_column', 5);

```