### PR TITLE
Wrong doc reference for table.index

### DIFF
--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -245,7 +245,7 @@ export default class Sidebar extends Component {
           <li>– <a href="#Schema-collate">collate</a></li>
           <li>– <a href="#Schema-inherits">inherits</a></li>
           <li>– <a href="#Schema-specificType">specificType</a></li>
-          <li>– <a href="#Schema-index">index</a></li>
+          <li>– <a href="#Schema-table-index">index</a></li>
           <li>– <a href="#Schema-dropIndex">dropIndex</a></li>
           <li>– <a href="#Schema-setNullable">setNullable</a></li>
           <li>– <a href="#Schema-dropNullable">dropNullable</a></li>


### PR DESCRIPTION
The documentation link reference for the `table.index` is incorrect, it currently links to the `column.index`, this corrects that issue.