### PR TITLE
Fix Algolia Search Box redirecting to a 404 page

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -11,8 +11,8 @@ export default defineConfig({
   ],
   themeConfig: {
     logo: '/knex-logo.png',
-    repo: 'knex/knex',  
-    docsRepo: 'knex/documentation',  
+    repo: 'knex/knex',
+    docsRepo: 'knex/documentation',
     docsDir: 'src',
     docsBranch: 'main',
     editLinks: true,
@@ -37,7 +37,7 @@ export default defineConfig({
       appId: 'V7E3EHUPD6',
       apiKey: '44b5077836c1c8fba0f364383dde7fb4',
       indexName: 'knex',
-      initialQuery: 'Installation',
+      initialQuery: '',
     }
   },
    vite: {

--- a/.vitepress/theme/AlgoliaSearchBox.vue
+++ b/.vitepress/theme/AlgoliaSearchBox.vue
@@ -79,8 +79,20 @@ function initialize(userOptions: any) {
       },
       transformItems: (items: DocSearchHit[]) => {
         return items.map((item) => {
+          // The original base URL of this website is apparently a GitHub pages domain
+          // in which every page seems to start with the path `/knex`.
+          // This effectively breaks the algolia search box in the `knexjs.org` domain
+          // since all items in the search box link to pages with paths that start with
+          // `/knex`, which in this domain seem to not start with `/knex`, so using
+          // the search box effectively makes any result redirect to a 404 page.
+          // This fix attempts to remove the `/knex` prefix from all results of
+          // the search box.
+          const url = new URL(item.url);
+          if(url.pathname.startsWith('/knex'))
+            url.pathname = url.pathname.replace('/knex', '');
+
           return Object.assign({}, item, {
-            url: getRelativePath(item.url)
+            url: getRelativePath(url.href)
           })
         })
       },


### PR DESCRIPTION
As commented in the code, apparently the original base URL of this documentation is apparently a GitHub pages domain in which every page seems to start with the path `/knex`. This effectively breaks the Algolia search box in the `knexjs.org` domain since all items in the search box link to pages with paths that start with `/knex`, which in this domain seem to not start with `/knex`, so using the search box effectively makes any result redirect to a 404 page. This fix attempts to remove the `/knex` prefix from all results of the search box.

Though the actual fix to this might be updating settings or something in Algolia to index the actual domain rather than the GitHub pages domain but I'm not sure and this is just a guess.

This also will address this [issue](https://github.com/knex/documentation/issues/408).

I also removed the initial `Installation` text when using the search box.