### PR TITLE
Update links in guide

### DIFF
--- a/src/guide/index.md
+++ b/src/guide/index.md
@@ -237,7 +237,7 @@ const customUserParam = knexWithParams
 
 ### debug
 
-Passing a `debug: true` flag on your initialization object will turn on [debugging](#Builder-debug) for all queries.
+Passing a `debug: true` flag on your initialization object will turn on [debugging](/guide/query-builder.html#debug) for all queries.
 
 ### asyncStackTraces
 
@@ -328,7 +328,7 @@ const knex = require('knex')({
 
 ### migrations
 
-For convenience, the any migration configuration may be specified when initializing the library. Read the [Migrations](#Migrations) section for more information and a full list of configuration options.
+For convenience, the any migration configuration may be specified when initializing the library. Read the [Migrations](/guide/migrations.html) section for more information and a full list of configuration options.
 
 ```js
 const knex = require('knex')({
@@ -348,7 +348,7 @@ const knex = require('knex')({
 
 ### postProcessResponse
 
-Hook for modifying returned rows, before passing them forward to user. One can do for example snake\_case -> camelCase conversion for returned columns with this hook. The `queryContext` is only available if configured for a query builder instance via [queryContext](#Builder-queryContext).
+Hook for modifying returned rows, before passing them forward to user. One can do for example snake\_case -> camelCase conversion for returned columns with this hook. The `queryContext` is only available if configured for a query builder instance via [queryContext](/guide/schema-builder.html#querycontext).
 
 ```js
 const knex = require('knex')({
@@ -372,7 +372,7 @@ Knex supports transforming identifier names automatically to quoted versions for
 
 With `wrapIdentifier` one may override the way how identifiers are transformed. It can be used to override default functionality and for example to help doing `camelCase` -> `snake_case` conversion.
 
-Conversion function `wrapIdentifier(value, dialectImpl, context): string` gets each part of the identifier as a single `value`, the original conversion function from the dialect implementation and the `queryContext`, which is only available if configured for a query builder instance via [builder.queryContext](#Builder-queryContext), and for schema builder instances via [schema.queryContext](#Schema-queryContext) or [table.queryContext](#Schema-table-queryContext). For example, with the query builder, `knex('table').withSchema('foo').select('table.field as otherName').where('id', 1)` will call `wrapIdentifier` converter for following values `'table'`, `'foo'`, `'table'`, `'field'`, `'otherName'` and `'id'`.
+Conversion function `wrapIdentifier(value, dialectImpl, context): string` gets each part of the identifier as a single `value`, the original conversion function from the dialect implementation and the `queryContext`, which is only available if configured for a query builder instance via [builder.queryContext](/guide/query-builder.html#querycontext), and for schema builder instances via [schema.queryContext](/guide/schema-builder.html#querycontext) or [table.queryContext](/guide/schema-builder.html#querycontext-1). For example, with the query builder, `knex('table').withSchema('foo').select('table.field as otherName').where('id', 1)` will call `wrapIdentifier` converter for following values `'table'`, `'foo'`, `'table'`, `'field'`, `'otherName'` and `'id'`.
 
 ```js
 const knex = require('knex')({


### PR DESCRIPTION
It appears that during the recent restructure some of the links got broken.

I just stumbled upon this issue in the `/guide` page, but I imagine there are some other links on the page that should be updated as well. I apologize that this PR is just targeting a subsection of the documentation, but I didn't have the time to skim through the other documents.

Thanks for your hard work!