### PR TITLE
docs: uuidToBin and binToUuid are in the wrong order

### DIFF
--- a/src/guide/utility.md
+++ b/src/guide/utility.md
@@ -39,11 +39,11 @@ Return the current timestamp with a precision (optional)
 table.datetime('some_time', { precision: 6 }).defaultTo(knex.fn.now(6))
 ```
 
-## binToUuid
+## uuidToBin
 
-**knex.fn.binToUuid(binaryUuid)**
+**knex.fn.uuidToBin(uuid)**
 
-Convert a binary uuid (binary(16)) to a string uuid (char(36))
+Convert a string uuid (char(36)) to a binary uuid (binary(16))
 
 ```js
 knex.schema.createTable('uuid_table', (t) => {
@@ -54,13 +54,13 @@ knex('uuid_table').insert({
 });
 ```
 
-## uuidToBin
+## binToUuid
 
-**knex.fn.uuidToBin(uuid)**
+**knex.fn.binToUuid(binaryUuid)**
 
-Convert a uuid (char(16)) to a binary uuid (binary(36))
+Convert a binary uuid (binary(16)) to a string uuid (char(36))
 
-```ts
+```js
 const res = await knex('uuid_table').select('uuid_col_binary');
 knex.fn.binToUuid(res[0].uuid_col_binary)
 ```


### PR DESCRIPTION
The code examples of uuidToBin and binToUuid where in the wrong order. I switched the heading and description of both so the createTable and  select statements are still correct.
I also changed 'convert a uuid (char(16))' to 'convert a string uuid (char(36))' in uuidToBin to match the description of binToUuid and the corresponding code example.
In addition I changed the specified language of the binToUuid code example from ts to js to match the language definitions of the other code examples.