### PR TITLE
Fix erroneous basic config example

### DIFF
--- a/src/guide/migrations.md
+++ b/src/guide/migrations.md
@@ -176,23 +176,21 @@ module.exports = {
 };
 ```
 
-you can also export an async function from the knexfile. This is useful when you need to fetch credentials from a secure location like vault
+You can also use an async function to get connection details for your configuration. This is useful when you need to fetch credentials from a secure location like vault.
 
 ```js
-async function fetchConfiguration() {
+const getPassword = async () => {
   // TODO: implement me
-  return {
-    client: 'pg',
-    connection: { user: 'me', password: 'my_pass' }
-  }
+  return 'my_pass'
 }
 
-module.exports = async () => {
-  const configuration = await fetchConfiguration();
-  return {
-    ...configuration,
-    migrations: {}
-  }
+module.exports = {
+  client: 'pg',
+  connection: async () => {
+    const password = await getPassword()
+    return { user: 'me', password }
+  },
+  migrations: {}
 };
 ```
 


### PR DESCRIPTION
Fixes the example of how to use an async function to get connection details.

The current example shows you can export an async function returning an entire [`Config`](https://github.com/knex/knex/blob/2dadde4214d9ee333adccfa517089647e94d23be/types/index.d.ts#L2698) object. However, the [type definition](https://github.com/knex/knex/blob/2dadde4214d9ee333adccfa517089647e94d23be/types/index.d.ts#L2703) shows that the `connection` property can be an async function. I can confirm that TypeScript won't compile when following the current example.