### PR TITLE
Updated index.md

### DIFF
--- a/src/guide/index.md
+++ b/src/guide/index.md
@@ -376,7 +376,7 @@ const knex = require('knex')({
 
 ### migrations
 
-For convenience, the any migration configuration may be specified when initializing the library. Read the [Migrations](https://knexjs.org/guide/migrations.html) section for more information and a full list of configuration options.
+For convenience, any migration configuration may be specified when initializing the library. Read the [Migrations](https://knexjs.org/guide/migrations.html) section for more information and a full list of configuration options.
 
 ```js
 const knex = require('knex')({


### PR DESCRIPTION
removed word 'the' before 'any' in migrations section to remove the confusion