### PR TITLE
Improve documentation for extending QueryBuilder

### DIFF
--- a/src/guide/query-builder.md
+++ b/src/guide/query-builder.md
@@ -1684,8 +1684,8 @@ It allows to add custom function to the Query Builder.
 Example:
 
 ```ts
-const Knex = require('knex');
-Knex.QueryBuilder.extend('customSelect', function(value) {
+const { knex } = require('knex');
+knex.QueryBuilder.extend('customSelect', function(value) {
   return this.select(this.client.raw(`${value} as value`));
 });
 
@@ -1704,7 +1704,7 @@ import { Knex as KnexOriginal } from 'knex';
 
 declare module 'knex' {
   namespace Knex {
-    interface QueryBuilder {
+    interface QueryInterface {
       customSelect<TRecord, TResult>(value: number): KnexOriginal.QueryBuilder<TRecord, TResult>;
     }
   }


### PR DESCRIPTION
Changes made:
1. Changed variable where `QueryBuilder` class is located at. `Knex.QueryBuilder` is a typescript interface defined in `Knex` namespace. `QueryBuilder` class is located at `knex.QueryBuilder`.
2. Changed `QueryBuilder` interface to `QueryInterface` in custom typescript definitions. To make the custom method appear at `knex()` object, we should augment `QueryInterface`, since it's the type `Knex` interface extends.