### PR TITLE
Fixed documentation typo

### DIFF
--- a/src/guide/migrations.md
+++ b/src/guide/migrations.md
@@ -552,7 +552,7 @@ Seed and migration files need to follow Knex conventions
  * Same as with the CommonJS modules
  * You will need to export a "seed" named function.
  * */
-export function seed(next) {
+export function seed(knex) {
   // ... seed logic here
 }
 


### PR DESCRIPTION
Based on the source code generated, I think the documentation contained a typo.