### PR TITLE
fix doc typo NODE\_ENV to NODE_ENV

### DIFF
--- a/src/guide/migrations.md
+++ b/src/guide/migrations.md
@@ -20,7 +20,7 @@ The migration CLI accepts the following general command-line options. You can vi
 - `--connection [address]`: Set the DB connection
 - `--migrations-table-name`: Set the migration table name
 - `--migrations-directory`: Set the migrations directory
-- `--env`: environment, default: `process.env.NODE\_ENV || development`
+- `--env`: environment, default: `process.env.NODE_ENV || development`
 - `--esm`: [Enables ESM module interoperability](#esm-interop)
 - `--help`: Display help text for a particular command and exit.
 


### PR DESCRIPTION
fixed line from:-

--env: environment, default: process.env.NODE[backslash]_ENV || development

To:-

--env: environment, default: process.env.NODE_ENV || development