### PR TITLE
adds documentation about how to group and order inputs to a union

### DIFF
--- a/src/guide/query-builder.md
+++ b/src/guide/query-builder.md
@@ -635,6 +635,14 @@ knex.select('*')
   )
 ```
 
+If you want to apply `orderBy`, `groupBy`, `limit`, `offset` or `having` to inputs of the union you need to use `knex.union` as a base statement. If you don't do this, those clauses will get appended to the end of the union.
+
+```js
+const users = knex('users').select('id', 'name').groupBy('id')
+const invitations = knex('invitations').select('id', 'name').orderBy('expires_at')
+knex.union([users, invitations])
+```
+
 ### unionAll
 
 **.unionAll([\*queries], [wrap])**

--- a/src/guide/query-builder.md
+++ b/src/guide/query-builder.md
@@ -638,10 +638,22 @@ knex.select('*')
 If you want to apply `orderBy`, `groupBy`, `limit`, `offset` or `having` to inputs of the union you need to use `knex.union` as a base statement. If you don't do this, those clauses will get appended to the end of the union.
 
 ```js
-const users = knex('users').select('id', 'name').groupBy('id')
-const invitations = knex('invitations').select('id', 'name').orderBy('expires_at')
-knex.union([users, invitations])
+// example showing how clauses get appended to the end of the query
+knex('users')
+  .select('id', 'name')
+  .groupBy('id')
+  .union(
+    knex('invitations')
+      .select('id', 'name')
+      .orderBy('expires_at')
+  )
+
+knex.union([
+  knex('users').select('id', 'name').groupBy('id'),
+  knex('invitations').select('id', 'name').orderBy('expires_at')
+])
 ```
+[before](https://michaelavila.com/knex-querylab/?query=NYOwpgHgFA5ArgZzAJwTAlAOiQGzAYwBdYBLAExgBoACGEAQwFswNMBzZAezgAcAhAJ6kKWOCBKcQUUJFIgAbiUL1CEkGiy4CxGOSq0GzVp2RkUg2JB4lkYBAH0VGdEA) and [after](https://michaelavila.com/knex-querylab/?query=NYOwpgHgdAriCWB7EAKA2qSKDkMDOYATntgJRQEA2YAxgC47wAm2ANAATYgCGAtmGSgBzQohgAHAEIBPRi1IdMERiABu8OtzpIQJclVoNszNpx79BiQkyIyckcfEJg8AfS1kAuqSA)
 
 ### unionAll
 


### PR DESCRIPTION
Issues about this here:
https://github.com/knex/knex/issues/739
https://github.com/knex/knex/issues/913

Here's the PR that addressed it:
https://github.com/knex/knex/pull/5030

This documentation should make it clear how to apply the following clauses to inputs of the union:

-  group
- having
- order
- limit
- offset

I'm open to some wording adjustments to fit better with the theme of the knex docs, but I hope I've conveyed the issue and solution