### PR TITLE
docs(pg): terminate code block in query-builder.md

### DIFF
--- a/src/guide/query-builder.md
+++ b/src/guide/query-builder.md
@@ -992,6 +992,7 @@ knex('accounts')
   .updateFrom('clients')
   .where('accounts.id', '=', 'clients.id')
   .where('clients.active', '=', false)
+```
 
 ### del / delete
 


### PR DESCRIPTION
I noticed after reviewing my changes in #476 that I'd forgotten to terminate the example code block, breaking the subsequent `.del` section.