### PR TITLE
docs: add TypeScript module augmentation help

### DIFF
--- a/src/guide/index.md
+++ b/src/guide/index.md
@@ -589,3 +589,14 @@ declare module 'knex/types/tables' {
   }
 }
 ```
+
+When TypeScript is configured to use a modern module resolution setting (`node16`, `nodenext`, etc.), the compiler expects that the declared module name ends with a `.js` file type. You will need to declare your inferred types as follows instead:
+
+```ts
+// The trailing `.js` is required by the TypeScript compiler in certain configs:
+declare module 'knex/types/tables.js' { // <----- Different module path!!!
+  interface Tables {
+    // ...
+  }
+}
+```


### PR DESCRIPTION
I spent the last hour trying to figure out why my augmented types weren't being inferred. Turns out, the TypeScript compiler will silently ignore invalid module augmentations in `.d.ts` files. 🥲

Some fiddling in a normal `.ts` file left me with the discovery that the compiler was expecting the module path to follow my module resolution setting, which is set to a modern `node16`.

Figured I would save someone else an hour of their time and contribute this finding back to the docs. This is one of the few projects I've used that uses external module augmentation, so I hope this is the right place to contribute this knowledge!