### PR TITLE
fix redundant documentation

### DIFF
--- a/src/guide/index.md
+++ b/src/guide/index.md
@@ -312,12 +312,6 @@ Specify the client for the particular flavour of SQL you are interested in.
 ```js
 const pg = require('knex')({client: 'pg'});
 
-knex('table')
-  .insert({a: 'b'})
-  .returning('*')
-  .toString();
-// "insert into "table" ("a") values ('b')"
-
 pg('table')
   .insert({a: 'b'})
   .returning('*')


### PR DESCRIPTION
the knex object stated in the code block is redundant and can be removed to avoid confusion.