### PR TITLE
Update orderBy documentation to include using multiple calls for multiple columns

### DIFF
--- a/src/guide/query-builder.md
+++ b/src/guide/query-builder.md
@@ -2688,6 +2688,8 @@ knex('users').orderBy('name', 'desc', 'first')
 Multiple Columns:
 
 ```js
+knex('users').orderBy('email').orderBy('age', 'desc')
+
 knex('users').orderBy([
   'email', { column: 'age', order: 'desc' }
 ])


### PR DESCRIPTION
`Knex.js` supports using multiple `orderBy` calls to use multiple columns in the SQL `ORDER BY` clause. This pull request adds an example of this behavior to the documentation, to show that such a method is indeed supported by `Knex.js`.

This is a link to a unit test from the `Knex.js` repository demonstrating this behavior:
https://github.com/knex/knex/blob/master/test/unit/query/builder.js#L3434-L3456