### PR TITLE
Use detailed param name in Migration documentation

### DIFF
--- a/src/guide/migrations.md
+++ b/src/guide/migrations.md
@@ -390,8 +390,8 @@ class MyMigrationSource {
     return Promise.resolve(['migration1'])
   }
 
-  getMigrationName(migration) {
-    return migration;
+  getMigrationName(name) {
+    return name;
   }
 
   getMigration(migration) {


### PR DESCRIPTION
Hi there,
I found `migration` param to be ambiguous since it may be thought an entire migration or it's name.
I suggest to use `name` to make it clear.