### PR TITLE
Add QueryBuilder as a thing you can extend

### DIFF
--- a/src/guide/extending.md
+++ b/src/guide/extending.md
@@ -19,6 +19,10 @@ knex.ColumnBuilder.extend("functionName", function() {
     console.log('Custom Column Builder Function');
     return this;
 });
+knex.QueryBuilder.extend("functionName", function() {
+    console.log('Custom Query Builder Function');
+    return this;
+});
 ```
 
 
@@ -38,6 +42,9 @@ declare module "knex" {
         }
         interface ColumnBuilder {
             functionName (): Knex.ColumnBuilder;
+        }
+        interface QueryBuilder {
+            functionName (): Knex.QueryBuilder;
         }
     }
 }


### PR DESCRIPTION
While working with Knex, I noticed that Query builder was missing from the extending documentation, even though it is used in the tests and seems to be well supported. 