### PR TITLE
fix - Where example for conflict+merge

### DIFF
--- a/src/guide/query-builder.md
+++ b/src/guide/query-builder.md
@@ -942,7 +942,7 @@ knex('tableName')
     name: "John Doe",
     updated_at: timestamp,
   })
-  .where('updated_at', '<', timestamp)
+  .where('tableName.updated_at', '<', timestamp)
 ```
 
 ### upsert


### PR DESCRIPTION
### Problem

The current documentation for `where` after onConflict + merge does not seem correct.
Following the example, we receive the error `column reference "x" is ambiguous`.

### Root cause

This is because in the `where` condition of a onConflict + merge, we have access to both the `table` and `excluded`. 
https://www.postgresql.org/docs/current/sql-insert.html
https://dba.stackexchange.com/a/224167

So the alias of the column name is ambiguous between the `table` and `excluded`. 

We can actually see the table name being directly referenced in the _test case_ that this scenario was created for https://github.com/knex/knex/pull/4148/files#diff-57a163701cfad49b7c6cbdfb102667277345ba8de7e575f6966269b0c0d8d3a0R1557

### Solution

We could update with a custom where condition to actually use table name 
https://github.com/knex/knex/blame/4ca3dd5bc28e0665c5bed55026fac2ec45489d81/lib/dialects/postgres/query/pg-querycompiler.js#L37

but implicitly choosing one or the other feels dangerous. 

So this proposal is just to fix the documentation that shows the feature to work.
