### PR TITLE
Suggestion: Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Knex Issues
+  - name: Knex issue
     url: https://github.com/knex/knex/issues/new
     about: For bug reports in Knex itself
   - name: Support

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Knex Issues
+    url: https://github.com/knex/knex/issues/new
+    about: For bug reports in Knex itself
+  - name: Support
+    url: https://gitter.im/tgriesser/knex
+    about: For support, see Gitter or Stack Overflow

--- a/.github/ISSUE_TEMPLATE/documentation-issue.md
+++ b/.github/ISSUE_TEMPLATE/documentation-issue.md
@@ -1,0 +1,12 @@
+---
+name: Documentation issue
+about: Issues and suggestions for the documentation at https://knexjs.org/
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Link to relevant page:** https://knexjs.org/
+
+**Issue or suggestion**:


### PR DESCRIPTION
The [Knex site's](https://knexjs.org/) GitHub link points to the [documentation repo](https://github.com/knex/documentation) rather than the main project repo; I'm more familiar with OSS project websites linking to their project repos.

Possibly because of this, several of the open issues under https://github.com/knex/documentation appear to be about Knex itself, rather than issues or suggestions for the documentation website.

Using GitHub's [issue templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository) feature could help guide users to the appropriate place to file their issues.

See https://github.com/joshkel/knex-documentation/issues/new/choose for an example of what this looks like.

Just a suggestion - feel free to edit or ignore.