### PR TITLE
Add note that the documentation has been moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # knex.js documentation
 
+> [!IMPORTANT]
+> The documentation has been moved to the [knex](https://github.com/knex/knex) repo under the [`docs`](https://github.com/knex/knex/tree/master/docs) folder
+
 The vitepress documentation for [http://knexjs.org](http://knexjs.org)
 
 #### Development:


### PR DESCRIPTION
Added after
- https://github.com/knex/knex/pull/5792

@kibertoad Can you mark the repo read-only after this PR is merged? 